### PR TITLE
Fix Windows SDK version for CoreLib.

### DIFF
--- a/Source/CoreLib/CoreLib.vcxproj
+++ b/Source/CoreLib/CoreLib.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
@@ -61,7 +61,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CoreLib</RootNamespace>
     <ProjectGuid>{F9BE7957-8399-899E-0C49-E714FDDD4B65}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.10586.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
For some reason, all of the project files reference the Windows 8.1 SDK, except for CoreLib, which references a version of the Windows 10 SDK.

At least on my machine, this caused the build to fail (possibly because I didn't have the appropriate version of the SDK installed?), while switching to consistently use the 8.1 SDK on all projects led to a successful build.
