### PR TITLE
Fix up "hello" example.

### DIFF
--- a/Examples/hello/hello.cpp
+++ b/Examples/hello/hello.cpp
@@ -96,7 +96,7 @@ HRESULT initialize( ID3D11Device* dxDevice )
 
     // Add a module of code to the shader.
     // Note: we could call this multiple times to construct a complex effect
-    spShaderAddModule(spireShader, "HelloModule");
+    spShaderAddModuleByName(spireShader, "HelloModule");
 
     // Compile the constructed shader
     SpireCompilationResult* spireResult = spCompileShader(spireContext, spireShader);

--- a/Examples/hello/hello.spire
+++ b/Examples/hello/hello.spire
@@ -11,9 +11,6 @@ pipeline StandardPipeline
     input world ModelInstance;
     
     [Pinned]
-    input world SkeletonData;
-    
-    [Pinned]
     
     input world ViewUniform;
     
@@ -29,54 +26,48 @@ pipeline StandardPipeline
     extern @(CoarseVertex*, Fragment*) Uniform<MaterialUniform> MaterialUniformBlock; 
     import(MaterialUniform->CoarseVertex) uniformImport()
     {
-        return MaterialUniformBlock;
+        return project(MaterialUniformBlock);
     }
     import(MaterialUniform->Fragment) uniformImport()
     {
-        return MaterialUniformBlock;
+        return project(MaterialUniformBlock);
     }
 
     [Binding: "1"]
     extern @(CoarseVertex*, Fragment*) Uniform<ViewUniform> ViewUniformBlock;
     import(ViewUniform->CoarseVertex) uniformImport()
     {
-        return ViewUniformBlock;
+        return project(ViewUniformBlock);
     }
     import(ViewUniform->Fragment) uniformImport()
     {
-        return ViewUniformBlock;
+        return project(ViewUniformBlock);
     }
     
     [Binding: "0"]
     extern @(CoarseVertex*, Fragment*) Uniform<ModelInstance> ModelInstanceBlock;
     import(ModelInstance->CoarseVertex) uniformImport()
     {
-        return ModelInstanceBlock;
+        return project(ModelInstanceBlock);
     }
     import(ModelInstance->Fragment) uniformImport()
     {
-        return ModelInstanceBlock;
-    }
-    
-    [Binding: "3"]
-    extern @(CoarseVertex*) StorageBuffer<SkeletonData> SkeletonDataBlock;
-    import(SkeletonData->CoarseVertex) uniformImport()
-    {
-        return SkeletonDataBlock;
+        return project(ModelInstanceBlock);
     }
     
     [VertexInput]
     extern @CoarseVertex MeshVertex vertAttribIn;
     import(MeshVertex->CoarseVertex) vertexImport()
     {
-        return vertAttribIn;
+        return project(vertAttribIn);
     }
     
     extern @Fragment CoarseVertex CoarseVertexIn;
     import(CoarseVertex->Fragment) standardImport()
-        require trait IsTriviallyPassable(CoarseVertex)
+// TODO(tfoley): this trait doesn't seem to be implemented on `vec3`
+//        require trait IsTriviallyPassable(CoarseVertex)
     {
-        return CoarseVertexIn;
+        return project(CoarseVertexIn);
     }
     
     stage vs : VertexShader


### PR DESCRIPTION
The hello example got broken by three different changes:

- The API was changed so that calls to `spShaderAddModule()` now need to call `spShaderAddModuleByName()`
- The import operator syntax was changed to require `project()` calls
- The `StorageBuffer<>` type got removed (it was used in the pipeline declaration, but the actual shader doesn't need it)

This change fixes up the issues.