### PR TITLE
Scope work

### DIFF
--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -739,21 +739,20 @@ namespace Spire
 				codeWriter.Discard();
 				return stmt;
 			}
-			virtual RefPtr<StatementSyntaxNode> VisitVarDeclrStatement(VarDeclrStatementSyntaxNode* stmt) override
+
+            RefPtr<Variable> VisitDeclrVariable(Variable* varDecl)
 			{
-				for (auto & v : stmt->Variables)
+				AllocVarInstruction * varOp = AllocVar(varDecl->Type.Ptr());
+				varOp->Name = EscapeDoubleUnderscore(varDecl->Name.Content);
+				variables.Add(varDecl->Name.Content, varOp);
+				if (varDecl->Expr)
 				{
-					AllocVarInstruction * varOp = AllocVar(stmt->Type.Ptr());
-					varOp->Name = EscapeDoubleUnderscore(v->Name.Content);
-					variables.Add(v->Name.Content, varOp);
-					if (v->Expr)
-					{
-						v->Expr->Accept(this);
-						Assign(varOp, PopStack());
-					}
+					varDecl->Expr->Accept(this);
+					Assign(varOp, PopStack());
 				}
-				return stmt;
+				return varDecl;
 			}
+
 			virtual RefPtr<StatementSyntaxNode> VisitExpressionStatement(ExpressionStatementSyntaxNode* stmt) override
 			{
 				stmt->Expression->Accept(this);

--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -606,23 +606,11 @@ namespace Spire
 			{
 				RefPtr<ForInstruction> instr = new ForInstruction();
 				variables.PushScope();
-				if (stmt->TypeDef)
-				{
-					AllocVarInstruction * varOp = AllocVar(stmt->IterationVariableType.Ptr());
-					varOp->Name = EscapeDoubleUnderscore(stmt->IterationVariable.Content);
-					variables.Add(stmt->IterationVariable.Content, varOp);
-				}
-				ILOperand * iterVar = nullptr;
-				if (stmt->IterationVariable.Content.Length() && !variables.TryGetValue(stmt->IterationVariable.Content, iterVar))
-					throw InvalidProgramException("Iteration variable not found in variables dictionary. This should have been checked by semantics analyzer.");
-				if (stmt->InitialExpression)
-				{
-					codeWriter.PushNode();
-					stmt->InitialExpression->Accept(this);
-					PopStack();
-					instr->InitialCode = codeWriter.PopNode();
-				}
-
+                if (auto initStmt = stmt->InitialStatement.Ptr())
+                {
+                    // TODO(tfoley): any of this push-pop malarky needed here?
+                    initStmt->Accept(this);
+                }
 				if (stmt->PredicateExpression)
 				{
 					codeWriter.PushNode();

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -1009,28 +1009,19 @@ namespace Spire
 			ReadToken(TokenType::LParent);
 			if (IsTypeKeyword())
 			{
-				stmt->TypeDef = ParseType();
-				stmt->IterationVariable = ReadToken(TokenType::Identifier);
-				ReadToken(TokenType::OpAssign);
-				stmt->InitialExpression = ParseExpression();
-				RefPtr<BinaryExpressionSyntaxNode> assignment = new BinaryExpressionSyntaxNode();
-				assignment->Operator = Operator::Assign;
-				FillPosition(assignment.Ptr());
-				assignment->Position = stmt->IterationVariable.Position;
-				RefPtr<VarExpressionSyntaxNode> varExpr = new VarExpressionSyntaxNode();
-				FillPosition(varExpr.Ptr());
-				varExpr->Position = stmt->IterationVariable.Position;
-				varExpr->Variable = stmt->IterationVariable.Content;
-				assignment->LeftExpression = varExpr;
-				assignment->RightExpression = stmt->InitialExpression;
-				stmt->InitialExpression = assignment;
+                stmt->InitialStatement = ParseVarDeclrStatement();
 			}
 			else
 			{
-				if (!LookAheadToken(TokenType::Semicolon))
-					stmt->InitialExpression = ParseExpression();
+                if (!LookAheadToken(TokenType::Semicolon))
+                {
+					stmt->InitialStatement = ParseExpressionStatement();
+                }
+                else
+                {
+			        ReadToken(TokenType::Semicolon);
+                }
 			}
-			ReadToken(TokenType::Semicolon);
 			if (!LookAheadToken(TokenType::Semicolon))
 				stmt->PredicateExpression = ParseExpression();
 			ReadToken(TokenType::Semicolon);

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -947,20 +947,9 @@ namespace Spire
 			virtual RefPtr<StatementSyntaxNode> VisitForStatement(ForStatementSyntaxNode *stmt) override
 			{
 				loops.Add(stmt);
-				VariableEntry iterVar;
-				if (stmt->TypeDef != nullptr)
+				if (stmt->InitialStatement)
 				{
-					stmt->IterationVariableType = TranslateTypeNode(stmt->TypeDef);
-					VariableEntry varEntry;
-					varEntry.IsComponent = false;
-					varEntry.Name = stmt->IterationVariable.Content;
-					varEntry.Type.DataType = stmt->IterationVariableType;
-					stmt->Scope->Variables.AddIfNotExists(stmt->IterationVariable.Content, varEntry);
-				}
-				
-				if (stmt->InitialExpression)
-				{
-					stmt->InitialExpression = stmt->InitialExpression->Accept(this).As<ExpressionSyntaxNode>();
+					stmt->InitialStatement = stmt->InitialStatement->Accept(this).As<StatementSyntaxNode>();
 				}
 				if (stmt->PredicateExpression)
 				{

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -217,16 +217,14 @@ namespace Spire
 		ForStatementSyntaxNode * ForStatementSyntaxNode::Clone(CloneContext & ctx)
 		{
 			auto rs = CloneSyntaxNodeFields(new ForStatementSyntaxNode(*this), ctx);
-			if (InitialExpression)
-				rs->InitialExpression = InitialExpression->Clone(ctx);
+			if (InitialStatement)
+				rs->InitialStatement = InitialStatement->Clone(ctx);
 			if (SideEffectExpression)
 				rs->SideEffectExpression = SideEffectExpression->Clone(ctx);
 			if (PredicateExpression)
 				rs->PredicateExpression = PredicateExpression->Clone(ctx);
 			if (Statement)
 				rs->Statement = Statement->Clone(ctx);
-			if (rs->TypeDef)
-				rs->TypeDef = TypeDef->Clone(ctx);
 			return rs;
 		}
 		RefPtr<SyntaxNode> IfStatementSyntaxNode::Accept(SyntaxVisitor * visitor)

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -6,14 +6,19 @@ namespace Spire
 {
 	namespace Compiler
 	{
-		bool Scope::FindVariable(const String & name, VariableEntry & variable)
-		{
-			if (Variables.TryGetValue(name, variable))
-				return true;
-			if (Parent)
-				return Parent->FindVariable(name, variable);
-			return false;
-		}
+    Decl* Scope::LookUp(String const& name)
+    {
+        Scope* scope = this;
+        while (scope)
+        {
+            Decl* decl = nullptr;
+            if (scope->decls.TryGetValue(name, decl))
+                return decl;
+
+            scope = scope->Parent;
+        }
+        return nullptr;
+    }
 
 		bool BasicExpressionType::Equals(const ExpressionType * type) const
 		{

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -262,10 +262,7 @@ namespace Spire
 		VarDeclrStatementSyntaxNode * VarDeclrStatementSyntaxNode::Clone(CloneContext & ctx)
 		{
 			auto rs = CloneSyntaxNodeFields(new VarDeclrStatementSyntaxNode(*this), ctx);
-			rs->TypeNode = TypeNode->Clone(ctx);
-			rs->Variables.Clear();
-			for (auto & var : Variables)
-				rs->Variables.Add(var->Clone(ctx));
+            rs->decl = rs->decl->Clone(ctx);
 			return rs;
 		}
 		RefPtr<SyntaxNode> Variable::Accept(SyntaxVisitor * visitor)
@@ -502,6 +499,20 @@ namespace Spire
 			rs->Import = Import->Clone(ctx);
 			return rs;
 		}
+
+        RefPtr<SyntaxNode> MultiDecl::Accept(SyntaxVisitor * visitor)
+        {
+            return visitor->VisitMultiDecl(this);
+        }
+
+        MultiDecl * MultiDecl::Clone(CloneContext & ctx)
+        {
+            auto rs = CloneSyntaxNodeFields(new MultiDecl(*this), ctx);
+            for (auto& d : rs->decls)
+                d = d->Clone(ctx);
+            return rs;
+        }
+
 		RefPtr<SyntaxNode> StructField::Accept(SyntaxVisitor * visitor)
 		{
 			return visitor->VisitStructField(this);

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -955,11 +955,8 @@ namespace Spire
 		class ForStatementSyntaxNode : public StatementSyntaxNode
 		{
 		public:
-			RefPtr<TypeSyntaxNode> TypeDef;
-			RefPtr<ExpressionType> IterationVariableType;
-			Token IterationVariable;
-
-			RefPtr<ExpressionSyntaxNode> InitialExpression, SideEffectExpression, PredicateExpression;
+			RefPtr<StatementSyntaxNode> InitialStatement;
+			RefPtr<ExpressionSyntaxNode> SideEffectExpression, PredicateExpression;
 			RefPtr<StatementSyntaxNode> Statement;
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
 			virtual ForStatementSyntaxNode * Clone(CloneContext & ctx) override;
@@ -1090,8 +1087,8 @@ namespace Spire
 			}
 			virtual RefPtr<StatementSyntaxNode> VisitForStatement(ForStatementSyntaxNode* stmt)
 			{
-				if (stmt->InitialExpression)
-					stmt->InitialExpression = stmt->InitialExpression->Accept(this).As<ExpressionSyntaxNode>();
+				if (stmt->InitialStatement)
+					stmt->InitialStatement = stmt->InitialStatement->Accept(this).As<StatementSyntaxNode>();
 				if (stmt->PredicateExpression)
 					stmt->PredicateExpression = stmt->PredicateExpression->Accept(this).As<ExpressionSyntaxNode>();
 				if (stmt->SideEffectExpression)

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -276,21 +276,12 @@ namespace Spire
 			EnumerableHashSet<String> PinnedWorlds; 
 		};
 
-
-		class VariableEntry
-		{
-		public:
-			String Name;
-			Type Type;
-			bool IsComponent = false;
-		};
-
 		class Scope
 		{
 		public:
 			Scope * Parent;
-			Dictionary<String, VariableEntry> Variables;
-			bool FindVariable(const String & name, VariableEntry & variable);
+            Dictionary<String, Decl*> decls;
+            Decl* LookUp(String const& name);
 			Scope()
 				: Parent(0)
 			{}

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -425,6 +425,13 @@ namespace Spire
 			RefPtr<ExpressionSyntaxNode> Expr;
         };
 
+        // A single variable declaration
+        class SingleVarDecl : public VarDeclBase
+        {
+        public:
+			RefPtr<TypeSyntaxNode> TypeNode;
+        };
+
         // A compound declaration that might declare multiple things,
         // using C-style declarator syntax
         class MultiDecl : public Decl
@@ -432,14 +439,17 @@ namespace Spire
         public:
             // The type specifier that all the declarations share
 			RefPtr<TypeSyntaxNode> TypeNode;
+
+            // The actual decls
+            List<RefPtr<Decl>> decls;
+
+            // Layout information (shared across the whole decl)
+			String LayoutString;
+
+			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
+            virtual MultiDecl * Clone(CloneContext & ctx) override;
         };
 
-        // A single variable declaration
-        class SingleVarDecl : public VarDeclBase
-        {
-        public:
-			RefPtr<TypeSyntaxNode> TypeNode;
-        };
 
         // A field of a `struct` type
 		class StructField :
@@ -704,10 +714,7 @@ namespace Spire
 		class VarDeclrStatementSyntaxNode : public StatementSyntaxNode
 		{
 		public:
-			RefPtr<TypeSyntaxNode> TypeNode;
-			RefPtr<ExpressionType> Type;
-			String LayoutString;
-			List<RefPtr<Variable>> Variables;
+            RefPtr<Decl> decl;
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
 			virtual VarDeclrStatementSyntaxNode * Clone(CloneContext & ctx) override;
 		};
@@ -1111,8 +1118,7 @@ namespace Spire
 			}
 			virtual RefPtr<StatementSyntaxNode> VisitVarDeclrStatement(VarDeclrStatementSyntaxNode* stmt)
 			{
-				for (auto & var : stmt->Variables)
-					var = var->Accept(this).As<Variable>();
+                stmt->decl = stmt->decl->Accept(this).As<Decl>();
 				return stmt;
 			}
 			virtual RefPtr<StatementSyntaxNode> VisitWhileStatement(WhileStatementSyntaxNode* stmt)
@@ -1224,6 +1230,16 @@ namespace Spire
 			{
 				return type;
 			}
+
+            virtual RefPtr<MultiDecl> VisitMultiDecl(MultiDecl* decl)
+            {
+                decl->TypeNode = decl->TypeNode->Accept(this).As<TypeSyntaxNode>();
+                for (auto& d : decl->decls)
+                {
+                    d = d->Accept(this).As<Decl>();
+                }
+                return decl;
+            }
 
 			virtual RefPtr<Variable> VisitDeclrVariable(Variable* dclr)
 			{


### PR DESCRIPTION
The basic gist of this PR is moving towards having the `Scope` type be used for *all* name lookup, instead of things going through a variety of different lists stored in different places.

For right now, the `Scope` type is still only used for variable declarations, but the changes here at least make it truly be a lookup table on declarations, not for `VariableEntry` values.

The first couple changes just clean up the statement syntax in cases where it could possibly introduce a variable declaration, so that it always used a true `Decl`. Then the final change just alters how the `Scope` stores declarations.

Note: It might be best to hold off on merging this PR until I can put some more tests into place, since I don't have any tests right now that cover `for` loops, for example.