### PR TITLE
Small fixes for VS2013/Falcor build.

### DIFF
--- a/Source/CoreLib/Array.h
+++ b/Source/CoreLib/Array.h
@@ -126,7 +126,7 @@ namespace CoreLib
 		}
 
 		template<typename ...TArgs>
-		auto MakeArray(TArgs ...args)
+		auto MakeArray(TArgs ...args) -> Array<typename FirstType<TArgs...>::type, sizeof...(args)>
 		{
 			Array<typename FirstType<TArgs...>::type, sizeof...(args)> rs;
 			InsertArray(rs, args...);

--- a/Source/CoreLib/TextIO.cpp
+++ b/Source/CoreLib/TextIO.cpp
@@ -1,6 +1,12 @@
 #include "TextIO.h"
 #ifdef _WIN32
+#define NOMINMAX
+#define VC_EXTRALEAN
+#define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#undef NOMINMAX
+#undef VC_EXTRALEAN
+#undef WIN32_LEAN_AND_MEAN
 #define CONVERT_END_OF_LINE
 #endif
 

--- a/Source/SpireCore/TypeLayout.cpp
+++ b/Source/SpireCore/TypeLayout.cpp
@@ -9,6 +9,15 @@
 namespace Spire {
 namespace Compiler {
 
+size_t RoundToAlignment(size_t offset, size_t alignment)
+{
+	size_t remainder = offset % alignment;
+	if (remainder == 0)
+		return offset;
+	else
+		return offset + (alignment - remainder);
+}
+
 static size_t RoundUpToPowerOfTwo( size_t value )
 {
     // TODO(tfoley): I know this isn't a fast approach

--- a/Source/SpireLib/SpireLib.cpp
+++ b/Source/SpireLib/SpireLib.cpp
@@ -817,7 +817,7 @@ int spComponentInfoCollectionGetComponent(SpireComponentInfoCollection * collect
 	result->Name = (*list)[index].Name.Buffer();
 	result->Alignment = (*list)[index].Alignment;
 	result->Offset = (*list)[index].Offset;
-	result->Size = GetTypeSize((*list)[index].Type.Ptr());
+	result->Size = (int) GetTypeSize((*list)[index].Type.Ptr());
 	result->Register = (*list)[index].Register.Buffer();
 	result->TypeName = (*list)[index].TypeName.Buffer();
 	return 0;
@@ -851,8 +851,8 @@ SpireComponentInfoCollection * spModuleGetComponentsByWorld(SpireModule * module
         {
             LayoutInfo fieldInfo = GetLayout(comp.Type.Ptr(), layoutRules);
             size_t offset = layoutRules->AddStructField(&layoutInfo, fieldInfo);
-            comp.Offset = offset;
-            comp.Alignment = fieldInfo.alignment;
+            comp.Offset = (int) offset;
+            comp.Alignment = (int) fieldInfo.alignment;
         }
         layoutRules->EndStructLayout(&layoutInfo);
 	}
@@ -872,8 +872,8 @@ int spModuleGetRequiredComponents(SpireModule * module, SpireComponentInfo * buf
 	{
 		buffer[ptr].Name = comp.Name.Buffer();
 		buffer[ptr].TypeName = comp.TypeName.Buffer();
-		buffer[ptr].Alignment = GetTypeAlignment(comp.Type.Ptr());
-		buffer[ptr].Size = GetTypeSize(comp.Type.Ptr());
+		buffer[ptr].Alignment = (int) GetTypeAlignment(comp.Type.Ptr());
+		buffer[ptr].Size = (int) GetTypeSize(comp.Type.Ptr());
 		buffer[ptr].Offset = comp.Offset;
 		ptr++;
 	}


### PR DESCRIPTION
- Use C++11 version of "trailing return type" instead of more recent fully `auto` return type
- Change `#include` of `Windows.h` to use `NOMINMAX` to avoid conflict with `std::max` (not sure why that didn't trigger before now; maybe different Windows SDK versions used?)
- Fix up a few loss-of-precision warnings related to type layouts (the new code uses `size_t`, but the public API just uses `int`, and one function that had been used in the core of things was defined on `int`).