### PR TITLE
Fix function-like macros for `TokenList` change.

### DIFF
--- a/Source/SpireCore/Preprocessor.cpp
+++ b/Source/SpireCore/Preprocessor.cpp
@@ -473,6 +473,15 @@ static void PushMacroExpansion(
     PushInputStream(preprocessor, expansion);
 }
 
+static void AddEndOfStreamToken(
+    Preprocessor*       preprocessor,
+    PreprocessorMacro*  macro)
+{
+    Token token = PeekRawToken(preprocessor);
+    token.Type = TokenType::EndOfFile;
+    macro->tokens.mTokens.Add(token);
+}
+
 // Check whether the current token on the given input stream should be
 // treated as a macro invocation, and if so set up state for expanding
 // that macro.
@@ -565,6 +574,7 @@ static void MaybeBeginMacroExpansion(
                             // if we reach the end of the file,
                             // then we have an error, and need to
                             // bail out
+                            AddEndOfStreamToken(preprocessor, arg);
                             goto doneWithAllArguments;
 
                         case TokenType::RParent:
@@ -572,6 +582,7 @@ static void MaybeBeginMacroExpansion(
                             // then we are at the end of an argument
                             if (nesting == 0)
                             {
+                                AddEndOfStreamToken(preprocessor, arg);
                                 goto doneWithAllArguments;
                             }
                             // Otherwise we decrease our nesting depth, add
@@ -584,6 +595,7 @@ static void MaybeBeginMacroExpansion(
                             // then we are at the end of an argument
                             if (nesting == 0)
                             {
+                                AddEndOfStreamToken(preprocessor, arg);
                                 AdvanceRawToken(preprocessor);
                                 goto doneWithArgument;
                             }
@@ -602,8 +614,6 @@ static void MaybeBeginMacroExpansion(
 
                         // Add the token and continue parsing.
                         arg->tokens.mTokens.Add(AdvanceRawToken(preprocessor));
-
-
                     }
                 doneWithArgument: {}
                     // We've parsed an argument and should move onto


### PR DESCRIPTION
The `TokenList` change means that we now expect all token sequences to have an extra token "past the end" that represents the end of the stream. This is helpful for reporting good diagnostics.

When I made the change, I neglected to account for the way that we have arguments to function-like macros behave as if they were macros themselves (so that they hold token lists), and we didn't have any tests covering that case. This change puts in a fix.