### PR TITLE
Fix function-like macros for `TokenList` change.

### DIFF
--- a/Source/SpireCore/DiagnosticDefs.h
+++ b/Source/SpireCore/DiagnosticDefs.h
@@ -82,13 +82,13 @@ DIAGNOSTIC(-1, Note, seeOpeningToken, "see opening '$0'")
 DIAGNOSTIC(15300, Error, includeFailed, "failed to find include file '$0'")
 DIAGNOSTIC(-1, Error, noIncludeHandlerSpecified, "no `#include` handler was specified")
 
-// 154xx - macros
+// 154xx - macro definition
 DIAGNOSTIC(15400, Warning, macroRedefinition, "redefinition of macro '$0'")
 DIAGNOSTIC(15401, Warning, macroNotDefined, "macro '$0' is not defined")
 DIAGNOSTIC(15403, Error, expectedTokenInMacroParameters, "expected '$0' in macro parameters")
 
-DIAGNOSTIC(15401, Warning, endOfInputInMacroInvocation, "end of input in macro arguments")
-
+// 155xx - macro expansion
+DIAGNOSTIC(15500, Warning, expectedTokenInMacroArguments, "expected '$0' in macro invocation")
 
 // 159xx - user-defined error/warning
 DIAGNOSTIC(15900, Error,    userDefinedError,   "#error: $0")

--- a/Tests/Preprocessor/define-function-like.spire
+++ b/Tests/Preprocessor/define-function-like.spire
@@ -1,0 +1,18 @@
+// support for function-like macros
+
+#define FOO(x) 1.0 + x
+
+float foo(float y) { return FOO(y) * 2.0; }
+
+// simple token pasting
+
+#define PASTE(a,b) a##b
+
+PASTE(flo,at) bar() { return 0.0; }
+
+// no space before parens? not a function-like macro
+
+#define M (x) - (x)
+
+// Error: undefined identifier `x`
+float bar(float a) { return M(a); }

--- a/Tests/Preprocessor/define-function-like.spire.expected
+++ b/Tests/Preprocessor/define-function-like.spire.expected
@@ -1,0 +1,7 @@
+result code = -1
+standard error = {
+Tests/Preprocessor/define-function-like.spire(15): error 30015: undefined identifier 'x'.
+Tests/Preprocessor/define-function-like.spire(15): error 30015: undefined identifier 'x'.
+}
+standard output = {
+}


### PR DESCRIPTION
The `TokenList` change means that we now expect all token sequences to have an extra token "past the end" that represents the end of the stream. This is helpful for reporting good diagnostics.

When I made the change, I neglected to account for the way that we have arguments to function-like macros behave as if they were macros themselves (so that they hold token lists), and we didn't have any tests covering that case. This change puts in a fix.

I then added a test case to make sure that I wouldn't break function-like macro expansion again, and when doing that I noticed that it was actually kind of broken (the closing `)` at an invocation site wasn't being consumed). I fixed things up using the new test case.

We should add tests more often!