### PR TITLE
Fix bug introduced in 1eee18256190996eddf8c1613ef3fffae0caa372

### DIFF
--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -129,7 +129,8 @@ namespace Spire
 		public:
 			virtual RefPtr<StructSyntaxNode> VisitStruct(StructSyntaxNode * st) override
 			{
-                TranslateStructType(st, &genericTypeMappings);
+                RefPtr<ILStructType> structType = TranslateStructType(st, &genericTypeMappings);
+                result.Program->Structs.Add(structType);
 				return st;
 			}
 			virtual void ProcessFunction(FunctionSyntaxNode * func) override

--- a/Tests/FrontEnd/pipeline-simple.spireh
+++ b/Tests/FrontEnd/pipeline-simple.spireh
@@ -1,0 +1,84 @@
+// pipeline-simple.spireh
+
+
+// TODO(tfoley): strip this down to a minimal pipeline
+
+pipeline StandardPipeline
+{
+    [Pinned]
+    input world MeshVertex;
+    
+    [Pinned]
+    input world ModelInstance;
+    
+    [Pinned]
+    
+    input world ViewUniform;
+    
+    [Pinned]
+    input world MaterialUniform;
+    
+    world CoarseVertex;// : "glsl(vertex:projCoord)" using projCoord export standardExport;
+    world Fragment;// : "glsl" export fragmentExport;
+    
+    require @CoarseVertex vec4 projCoord; 
+    
+    [Binding: "2"]
+    extern @(CoarseVertex*, Fragment*) Uniform<MaterialUniform> MaterialUniformBlock; 
+    import(MaterialUniform->CoarseVertex) uniformImport()
+    {
+        return project(MaterialUniformBlock);
+    }
+    import(MaterialUniform->Fragment) uniformImport()
+    {
+        return project(MaterialUniformBlock);
+    }
+
+    [Binding: "1"]
+    extern @(CoarseVertex*, Fragment*) Uniform<ViewUniform> ViewUniformBlock;
+    import(ViewUniform->CoarseVertex) uniformImport()
+    {
+        return project(ViewUniformBlock);
+    }
+    import(ViewUniform->Fragment) uniformImport()
+    {
+        return project(ViewUniformBlock);
+    }
+    
+    [Binding: "0"]
+    extern @(CoarseVertex*, Fragment*) Uniform<ModelInstance> ModelInstanceBlock;
+    import(ModelInstance->CoarseVertex) uniformImport()
+    {
+        return project(ModelInstanceBlock);
+    }
+    import(ModelInstance->Fragment) uniformImport()
+    {
+        return project(ModelInstanceBlock);
+    }
+    
+    [VertexInput]
+    extern @CoarseVertex MeshVertex vertAttribIn;
+    import(MeshVertex->CoarseVertex) vertexImport()
+    {
+        return project(vertAttribIn);
+    }
+    
+    extern @Fragment CoarseVertex CoarseVertexIn;
+    import(CoarseVertex->Fragment) standardImport()
+// TODO(tfoley): this trait doesn't seem to be implemented on `vec3`
+//        require trait IsTriviallyPassable(CoarseVertex)
+    {
+        return project(CoarseVertexIn);
+    }
+    
+    stage vs : VertexShader
+    {
+        World: CoarseVertex;
+        Position: projCoord;
+    }
+    
+    stage fs : FragmentShader
+    {
+        World: Fragment;
+    }
+}

--- a/Tests/FrontEnd/struct.spire
+++ b/Tests/FrontEnd/struct.spire
@@ -1,0 +1,42 @@
+// test that `struct` decls work
+
+#include "pipeline-simple.spireh"
+
+// struct declaration
+struct Foo
+{
+	vec3 a;
+	vec3 b;
+};
+
+// function on a struct
+Foo makeFoo(float x, float y)
+{
+	// local of struct type
+	Foo foo;
+	foo.a = vec3(x);
+	foo.b = vec3(y);
+	return foo;
+}
+
+shader Test : StandardPipeline
+{
+	// Uniform of struct type
+	@MaterialUniform Foo foo1;
+
+    @MeshVertex vec3 position;
+    @MeshVertex vec3 color;
+
+    @ModelInstance mat4 modelViewProjection;
+
+    public vec4 projCoord = modelViewProjection * vec4(position, 1.0);
+
+    // Component of struct type
+    // Note(tfoley): use of `public` here required to work around parser limitations
+    public Foo foo2 = makeFoo(color.x, color.y);
+
+    //
+    vec3 result = foo1.a + foo2.b;
+
+    out @Fragment vec4 colorTarget = vec4(result,1);
+}


### PR DESCRIPTION
That change had removed `StructSymbol` from the front-end, and mistakenly removed the logic in `CodeGenerator::VisitStruct` that actually added an `ILStructType` to the list of struct types to be emitted.

This change fixes the issue, and also adds a small test case that actually uses struct types in a few ways.
This test currently doesn't help a whole lot, though, because we don't have any end-to-end testing of generating code (in this case, just checking that the generated GLSL is okay would help).
Doing a better job with our tests should be a distinct change, though.

With this fix, the `SpireMiniEngine` project now seems to run correctly again.