### PR TITLE
Typedef support (and a bunch of small refactoring changes)

### DIFF
--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -1062,7 +1062,7 @@ namespace Spire
 				{
 					if (basicType->Func)
 					{
-						funcName = basicType->Func->SyntaxNode->IsExtern ? basicType->Func->SyntaxNode->Name : basicType->Func->SyntaxNode->InternalName;
+						funcName = basicType->Func->SyntaxNode->IsExtern ? basicType->Func->SyntaxNode->Name.Content : basicType->Func->SyntaxNode->InternalName;
 						for (auto & param : basicType->Func->SyntaxNode->Parameters)
 						{
 							if (param->Qualifier == ParameterQualifier::Out || param->Qualifier == ParameterQualifier::InOut)

--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -1044,7 +1044,7 @@ namespace Spire
 					}
 					else if (expr->BaseExpression->Type->IsStruct())
 					{
-						int id = expr->BaseExpression->Type->AsBasicType()->structDecl->FindField(expr->MemberName);
+						int id = expr->BaseExpression->Type->AsBasicType()->structDecl->FindFieldIndex(expr->MemberName);
 						GenerateIndexExpression(base, result.Program->ConstantPool->CreateConstant(id),
 							expr->Access == ExpressionAccess::Read);
 					}
@@ -1295,7 +1295,7 @@ namespace Spire
                 ilStructType->IsIntrinsic = structDecl->IsIntrinsic;
 
 
-                for (auto field : structDecl->Fields)
+                for (auto field : structDecl->GetFields())
                 {
                     ILStructType::ILStructField ilField;
                     ilField.FieldName = field->Name.Content;

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -264,6 +264,23 @@ namespace Spire
 			return rs;
 		}
 
+        static RefPtr<TypeDefDecl> ParseTypeDef(Parser* parser)
+        {
+            // Consume the `typedef` keyword
+            parser->ReadToken("typedef");
+
+            // TODO(tfoley): parse an actual declarator
+            auto type = parser->ParseType();
+
+            auto nameToken = parser->ReadToken(TokenType::Identifier);
+
+            RefPtr<TypeDefDecl> typeDefDecl = new TypeDefDecl();
+            typeDefDecl->Name = nameToken;
+            typeDefDecl->TypeNode = type;
+
+            return typeDefDecl;
+        }
+
 		RefPtr<ProgramSyntaxNode> Parser::ParseProgram()
 		{
 			scopeStack.Add(new Scope());
@@ -283,6 +300,8 @@ namespace Spire
 							program->Members.Add(ParsePipeline());
 						else if (LookAheadToken("struct"))
 							program->Members.Add(ParseStruct());
+						else if (LookAheadToken("typedef"))
+							program->Members.Add(ParseTypeDef(this));
 						else if (LookAheadToken("using"))
 						{
 							ReadToken("using");

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -735,7 +735,7 @@ namespace Spire
 				{
 					name = ReadToken(TokenType::Identifier);
 				}
-				function->Name = name.Content;
+				function->Name = name;
 				ReadToken(TokenType::LParent);
 				while(!tokenReader.IsAtEnd() && tokenReader.PeekTokenType() != TokenType::RParent)
 				{

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -788,7 +788,7 @@ namespace Spire
 					FillPosition(field.Ptr());
 					field->TypeNode = type;
 					field->Name = ReadToken(TokenType::Identifier);
-					rs->Fields.Add(field);
+					rs->Members.Add(field);
 					if (!LookAheadToken(TokenType::Comma))
 						break;
 					ReadToken(TokenType::Comma);

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -278,11 +278,11 @@ namespace Spire
 					try
 					{
 						if (LookAheadToken("shader") || LookAheadToken("module"))
-							program->Shaders.Add(ParseShader());
+							program->Members.Add(ParseShader());
 						else if (LookAheadToken("pipeline"))
-							program->Pipelines.Add(ParsePipeline());
+							program->Members.Add(ParsePipeline());
 						else if (LookAheadToken("struct"))
-							program->Structs.Add(ParseStruct());
+							program->Members.Add(ParseStruct());
 						else if (LookAheadToken("using"))
 						{
 							ReadToken("using");
@@ -291,7 +291,7 @@ namespace Spire
 						}
 						else if (IsTypeKeyword() || LookAheadToken("inline") || LookAheadToken("extern")
 							|| LookAheadToken("__intrinsic") || LookAheadToken(TokenType::Identifier))
-							program->Functions.Add(ParseFunction());
+							program->Members.Add(ParseFunction());
 						else if (LookAheadToken(TokenType::Semicolon))
 							ReadToken(TokenType::Semicolon);
 						else

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -844,7 +844,7 @@ namespace Spire
 
 			virtual RefPtr<StructSyntaxNode> VisitStruct(StructSyntaxNode * structNode) override
 			{
-                for (auto field : structNode->Fields)
+                for (auto field : structNode->GetFields())
                 {
                     field->Type = TranslateTypeNode(field->TypeNode);
                 }
@@ -1838,14 +1838,14 @@ namespace Spire
 				}
 				else if (baseType->IsStruct())
 				{
-					int id = baseType->AsBasicType()->structDecl->FindField(expr->MemberName);
-					if (id == -1)
+					StructField* field = baseType->AsBasicType()->structDecl->FindField(expr->MemberName);
+					if (!field)
 					{
 						expr->Type = ExpressionType::Error;
 						getSink()->diagnose(expr, Diagnostics::noMemberOfNameInType, expr->MemberName, baseType->AsBasicType()->structDecl);
 					}
 					else
-						expr->Type = baseType->AsBasicType()->structDecl->Fields[id]->Type;
+						expr->Type = field->Type;
 					if (auto bt = expr->Type->AsBasicType())
 					{
 						bt->IsLeftValue = baseType->AsBasicType()->IsLeftValue;

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -870,7 +870,7 @@ namespace Spire
 				auto returnType = TranslateTypeNode(functionNode->ReturnTypeNode);
 				functionNode->ReturnType = returnType;
 				StringBuilder internalName;
-				internalName << functionNode->Name;
+				internalName << functionNode->Name.Content;
 				HashSet<String> paraNames;
 				for (auto & para : functionNode->Parameters)
 				{
@@ -888,11 +888,11 @@ namespace Spire
 				RefPtr<FunctionSymbol> symbol = new FunctionSymbol();
 				symbol->SyntaxNode = functionNode;
 				symbolTable->Functions[functionNode->InternalName] = symbol;
-				auto overloadList = symbolTable->FunctionOverloads.TryGetValue(functionNode->Name);
+				auto overloadList = symbolTable->FunctionOverloads.TryGetValue(functionNode->Name.Content);
 				if (!overloadList)
 				{
-					symbolTable->FunctionOverloads[functionNode->Name] = List<RefPtr<FunctionSymbol>>();
-					overloadList = symbolTable->FunctionOverloads.TryGetValue(functionNode->Name);
+					symbolTable->FunctionOverloads[functionNode->Name.Content] = List<RefPtr<FunctionSymbol>>();
+					overloadList = symbolTable->FunctionOverloads.TryGetValue(functionNode->Name.Content);
 				}
 				overloadList->Add(symbol);
 				this->function = NULL;

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -524,10 +524,10 @@ namespace Spire
 				
 				if (shader->ParentPipelineName.Content.Length() == 0) // implicit pipeline
 				{
-					if (program->Pipelines.Count() == 1)
+					if (program->GetPipelines().Count() == 1)
 					{
 						shader->ParentPipelineName = shader->Name; // get line and col from shader name
-						shader->ParentPipelineName.Content = program->Pipelines.First()->Name.Content;
+						shader->ParentPipelineName.Content = program->GetPipelines().First()->Name.Content;
 					}
 					else if (!shader->IsModule)
 					{
@@ -768,13 +768,13 @@ namespace Spire
 				HashSet<String> funcNames;
 				this->program = programNode;
 				this->function = nullptr;
-				for (auto & s : program->Structs)
+				for (auto & s : program->GetStructs())
 				{
                     symbolTable->globalDecls.Add(s->Name.Content, s.Ptr());
 				}
-				for (auto & s : program->Structs)
+				for (auto & s : program->GetStructs())
 					VisitStruct(s.Ptr());
-				for (auto & func : program->Functions)
+				for (auto & func : program->GetFunctions())
 				{
 					VisitFunctionDeclaration(func.Ptr());
 					if (funcNames.Contains(func->InternalName))
@@ -793,16 +793,16 @@ namespace Spire
 					else
 						funcNames.Add(func->InternalName);
 				}
-				for (auto & func : program->Functions)
+				for (auto & func : program->GetFunctions())
 				{
 					func->Accept(this);
 				}
-				for (auto & pipeline : program->Pipelines)
+				for (auto & pipeline : program->GetPipelines())
 				{
 					VisitPipeline(pipeline.Ptr());
 				}
 				// build initial symbol table for shaders
-				for (auto & shader : program->Shaders)
+				for (auto & shader : program->GetShaders())
 				{
 					RefPtr<ShaderSymbol> shaderSym = new ShaderSymbol();
 					shaderSym->SyntaxNode = shader.Ptr();
@@ -812,7 +812,7 @@ namespace Spire
 					}
 					symbolTable->Shaders[shader->Name.Content] = shaderSym;
 				}
-				for (auto & shader : program->Shaders)
+				for (auto & shader : program->GetShaders())
 				{
 					VisitShaderPass1(shader.Ptr());
 				}

--- a/Source/SpireCore/ShaderCompiler.cpp
+++ b/Source/SpireCore/ShaderCompiler.cpp
@@ -309,10 +309,10 @@ namespace Spire
 							result.Program->Structs = context.Program->Structs;
 							result.Program->ConstantPool = context.Program->ConstantPool;
 						}
-						for (auto & s : programSyntaxNode->Structs)
+						for (auto & s : programSyntaxNode->GetStructs())
 							codeGen->ProcessStruct(s.Ptr());
 
-						for (auto & func : programSyntaxNode->Functions)
+						for (auto & func : programSyntaxNode->GetFunctions())
 							codeGen->ProcessFunction(func.Ptr());
 						for (auto & shader : shaderClosures)
 						{
@@ -330,10 +330,10 @@ namespace Spire
 						EnumerableHashSet<String> symbolsToGen;
 						for (auto & unit : units)
 						{
-							for (auto & shader : unit.SyntaxNode->Shaders)
+							for (auto & shader : unit.SyntaxNode->GetShaders())
 								if (!shader->IsModule)
 									symbolsToGen.Add(shader->Name.Content);
-							for (auto & func : unit.SyntaxNode->Functions)
+							for (auto & func : unit.SyntaxNode->GetFunctions())
 								symbolsToGen.Add(func->Name.Content);
 						}
 						auto IsSymbolToGen = [&](String & shaderName)

--- a/Source/SpireCore/ShaderCompiler.cpp
+++ b/Source/SpireCore/ShaderCompiler.cpp
@@ -334,7 +334,7 @@ namespace Spire
 								if (!shader->IsModule)
 									symbolsToGen.Add(shader->Name.Content);
 							for (auto & func : unit.SyntaxNode->Functions)
-								symbolsToGen.Add(func->Name);
+								symbolsToGen.Add(func->Name.Content);
 						}
 						auto IsSymbolToGen = [&](String & shaderName)
 						{

--- a/Source/SpireCore/SymbolTable.cpp
+++ b/Source/SpireCore/SymbolTable.cpp
@@ -435,7 +435,7 @@ namespace Spire
 				auto typeStr = type->ToString();
 				auto retType = PrintType(req->ReturnType, typeStr);
 				StringBuilder sbInternalName;
-				sbInternalName << req->Name;
+				sbInternalName << req->Name.Content;
 				for (auto & op : req->Parameters)
 				{
 					sbInternalName << "@" << PrintType(op->Type, typeStr);

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -134,18 +134,9 @@ namespace Spire
 		ProgramSyntaxNode * ProgramSyntaxNode::Clone(CloneContext & ctx)
 		{
 			auto rs = CloneSyntaxNodeFields(new ProgramSyntaxNode(*this), ctx);
-			rs->Structs.Clear();
-			for (auto & x : Structs)
-				rs->Structs.Add(x->Clone(ctx));
-			rs->Functions.Clear();
-			for (auto & x : Functions)
-				rs->Functions.Add(x->Clone(ctx));
-			rs->Pipelines.Clear();
-			for (auto & x : Pipelines)
-				rs->Pipelines.Add(x->Clone(ctx));
-			rs->Shaders.Clear();
-			for (auto & x : Shaders)
-				rs->Shaders.Add(x->Clone(ctx));
+			rs->Members.Clear();
+			for (auto & m : Members)
+				rs->Members.Add(m->Clone(ctx));
 			return rs;
 		}
 		RefPtr<SyntaxNode> FunctionSyntaxNode::Accept(SyntaxVisitor * visitor)

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -2,6 +2,8 @@
 #include "SyntaxVisitors.h"
 #include "SymbolTable.h"
 
+#include <assert.h>
+
 namespace Spire
 {
 	namespace Compiler
@@ -20,7 +22,7 @@ namespace Spire
         return nullptr;
     }
 
-		bool BasicExpressionType::Equals(const ExpressionType * type) const
+		bool BasicExpressionType::EqualsImpl(const ExpressionType * type) const
 		{
 			auto basicType = dynamic_cast<const BasicExpressionType*>(type);
 			if (basicType == nullptr)
@@ -32,14 +34,15 @@ namespace Spire
 				basicType->RecordTypeName == RecordTypeName);
 		}
 
-		bool BasicExpressionType::IsVectorType() const
+        ExpressionType* BasicExpressionType::CreateCanonicalType()
+        {
+            // A basic type is already canonical, in our setup
+            return this;
+        }
+
+		bool BasicExpressionType::IsVectorTypeImpl() const
 		{
 			return IsVector(BaseType);
-		}
-
-		bool BasicExpressionType::IsArray() const
-		{
-			return false;
 		}
 
 		CoreLib::Basic::String BasicExpressionType::ToString() const
@@ -515,6 +518,17 @@ namespace Spire
 		{
 			return visitor->VisitStruct(this);
 		}
+
+        RefPtr<SyntaxNode> TypeDefDecl::Accept(SyntaxVisitor * visitor)
+        {
+            return visitor->VisitTypeDefDecl(this);
+        }
+        TypeDefDecl* TypeDefDecl::Clone(CloneContext & ctx)
+        {
+            auto result = CloneSyntaxNodeFields(new TypeDefDecl(*this), ctx);
+            return result;
+        }
+
 		RefPtr<SyntaxNode> DiscardStatementSyntaxNode::Accept(SyntaxVisitor * visitor)
 		{
 			return visitor->VisitDiscardStatement(this);
@@ -524,10 +538,68 @@ namespace Spire
 			auto rs = CloneSyntaxNodeFields(new DiscardStatementSyntaxNode(*this), ctx);
 			return rs;
 		}
-		bool BasicExpressionType::IsIntegral() const
+		bool BasicExpressionType::IsIntegralImpl() const
 		{
 			return (BaseType == Compiler::BaseType::Int || BaseType == Compiler::BaseType::UInt || BaseType == Compiler::BaseType::Bool);
 		}
+
+
+        bool ExpressionType::IsIntegral() const
+        {
+            return GetCanonicalType()->IsIntegralImpl();
+        }
+
+        bool ExpressionType::Equals(const ExpressionType * type) const
+        {
+            return GetCanonicalType()->EqualsImpl(type->GetCanonicalType());
+        }
+
+        bool ExpressionType::IsVectorType() const
+        {
+            return GetCanonicalType()->IsVectorTypeImpl();
+        }
+
+        bool ExpressionType::IsArray() const
+        {
+            return GetCanonicalType()->IsArrayImpl();
+        }
+
+        bool ExpressionType::IsGenericType(String typeName) const
+        {
+            return GetCanonicalType()->IsGenericTypeImpl(typeName);
+        }
+
+        BasicExpressionType * ExpressionType::AsBasicType() const
+        {
+            return GetCanonicalType()->AsBasicTypeImpl();
+        }
+
+        ArrayExpressionType * ExpressionType::AsArrayType() const
+        {
+            return GetCanonicalType()->AsArrayTypeImpl();
+        }
+
+        GenericExpressionType * ExpressionType::AsGenericType() const
+        {
+            return GetCanonicalType()->AsGenericTypeImpl();
+        }
+
+        NamedExpressionType* ExpressionType::AsNamedType() const
+        {
+            return AsNamedTypeImpl();
+        }
+
+        ExpressionType* ExpressionType::GetCanonicalType() const
+        {
+            ExpressionType* et = const_cast<ExpressionType*>(this);
+            if (!et->canonicalType)
+            {
+                // TODO(tfoley): worry about thread safety here?
+                et->canonicalType = et->CreateCanonicalType();
+            }
+            return et->canonicalType;
+        }
+
 		bool ExpressionType::IsTexture() const
 		{
 			auto basicType = AsBasicType();
@@ -622,25 +694,25 @@ namespace Spire
 			Void = nullptr;
 			Error = nullptr;
 		}
-		bool ArrayExpressionType::IsIntegral() const
-		{
-			return false;
-		}
-		bool ArrayExpressionType::IsArray() const
+		bool ArrayExpressionType::IsArrayImpl() const
 		{
 			return true;
 		}
-		bool ArrayExpressionType::Equals(const ExpressionType * type) const
+		bool ArrayExpressionType::EqualsImpl(const ExpressionType * type) const
 		{
-			auto arrType = dynamic_cast<const ArrayExpressionType*>(type);
+			auto arrType = type->AsArrayType();
 			if (!arrType)
 				return false;
 			return (ArrayLength == arrType->ArrayLength && BaseType->Equals(arrType->BaseType.Ptr()));
 		}
-		bool ArrayExpressionType::IsVectorType() const
-		{
-			return false;
-		}
+        ExpressionType* ArrayExpressionType::CreateCanonicalType()
+        {
+            auto canonicalBaseType = BaseType->GetCanonicalType();
+            auto canonicalArrayType = new ArrayExpressionType();
+            canonicalArrayType->BaseType = canonicalBaseType;
+            canonicalArrayType->ArrayLength = ArrayLength;
+            return canonicalArrayType;
+        }
 		CoreLib::Basic::String ArrayExpressionType::ToString() const
 		{
 			if (ArrayLength > 0)
@@ -662,25 +734,21 @@ namespace Spire
 		{
 			return visitor->VisitGenericType(this);
 		}
-		bool GenericExpressionType::IsIntegral() const
+		bool GenericExpressionType::EqualsImpl(const ExpressionType * type) const
 		{
-			return false;
-		}
-		bool GenericExpressionType::IsArray() const
-		{
-			return false;
-		}
-		bool GenericExpressionType::Equals(const ExpressionType * type) const
-		{
-			if (auto gtype = dynamic_cast<const GenericExpressionType*>(type))
+			if (auto gtype = type->AsGenericType())
 				return GenericTypeName == gtype->GenericTypeName && gtype->BaseType->Equals(BaseType.Ptr());
 			
 			return false;
 		}
-		bool GenericExpressionType::IsVectorType() const
-		{
-			return false;
-		}
+        ExpressionType* GenericExpressionType::CreateCanonicalType()
+        {
+            auto canonicalBaseType = BaseType->GetCanonicalType();
+            auto canonicalGenericType = new GenericExpressionType();
+            canonicalGenericType->BaseType = canonicalBaseType;
+            canonicalGenericType->GenericTypeName = GenericTypeName;
+            return canonicalGenericType;
+        }
 		CoreLib::Basic::String GenericExpressionType::ToString() const
 		{
 			return GenericTypeName + "<" + BaseType->ToString() + ">";
@@ -691,6 +759,37 @@ namespace Spire
 			rs->BaseType = BaseType->Clone();
 			return rs;
 		}
+
+        // NamedExpressionType
+
+        String NamedExpressionType::ToString() const
+        {
+            return decl->Name.Content;
+        }
+
+        ExpressionType * NamedExpressionType::Clone()
+        {
+            NamedExpressionType* result = new NamedExpressionType();
+            result->decl = decl;
+            return result;
+        }
+
+        bool NamedExpressionType::EqualsImpl(const ExpressionType * /*type*/) const
+        {
+            assert(!"unreachable");
+            return false;
+        }
+
+        NamedExpressionType * NamedExpressionType::AsNamedTypeImpl() const
+        {
+            return const_cast<NamedExpressionType*>(this);
+        }
+
+        ExpressionType* NamedExpressionType::CreateCanonicalType()
+        {
+            return decl->Type->GetCanonicalType();
+        }
+
 		RefPtr<SyntaxNode> ImportExpressionSyntaxNode::Accept(SyntaxVisitor * visitor)
 		{
 			return visitor->VisitImportExpression(this);

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -513,14 +513,19 @@ namespace Spire
 			virtual ParameterSyntaxNode * Clone(CloneContext & ctx) override;
 		};
 
-		class FunctionSyntaxNode : public SyntaxNode
-		{
-		public:
-			String Name, InternalName;
-			RefPtr<ExpressionType> ReturnType;
-			RefPtr<TypeSyntaxNode> ReturnTypeNode;
+        class FunctionDeclBase : public Decl
+        {
+        public:
 			List<RefPtr<ParameterSyntaxNode>> Parameters;
 			RefPtr<BlockStatementSyntaxNode> Body;
+        };
+
+		class FunctionSyntaxNode : public FunctionDeclBase
+		{
+		public:
+			String InternalName;
+			RefPtr<ExpressionType> ReturnType;
+			RefPtr<TypeSyntaxNode> ReturnTypeNode;
 			bool IsInline;
 			bool IsExtern;
 			bool HasSideEffect;
@@ -535,13 +540,10 @@ namespace Spire
 			virtual FunctionSyntaxNode * Clone(CloneContext & ctx) override;
 		};
 
-		class ImportOperatorDefSyntaxNode : public Decl
+		class ImportOperatorDefSyntaxNode : public FunctionDeclBase
 		{
 		public:
-			Token Name;
 			Token SourceWorld, DestWorld;
-			List<RefPtr<ParameterSyntaxNode>> Parameters;
-			RefPtr<BlockStatementSyntaxNode> Body;
 			EnumerableDictionary<String, String> LayoutAttributes;
 			Token TypeName;
 			List<RefPtr<FunctionSyntaxNode>> Requirements;

--- a/Source/SpireCore/TypeLayout.cpp
+++ b/Source/SpireCore/TypeLayout.cpp
@@ -199,7 +199,7 @@ LayoutInfo GetLayout(ExpressionType* type, LayoutRulesImpl* rules)
         {
             LayoutInfo info = rules->BeginStructLayout();
 
-            for (auto field : structDecl->Fields)
+            for (auto field : structDecl->GetFields())
             {
                 rules->AddStructField(&info,
                     GetLayout(field->Type.Ptr(), rules));

--- a/Tests/FrontEnd/typedef.spire
+++ b/Tests/FrontEnd/typedef.spire
@@ -1,0 +1,14 @@
+// test that we can `typedef` a type
+
+typedef float F32;
+
+F32 foo()
+{
+	float x = 123.0;
+	return x;
+}
+
+float bar()
+{
+	return foo();
+}

--- a/Tests/Preprocessor/include-a.spireh
+++ b/Tests/Preprocessor/include-a.spireh
@@ -1,0 +1,3 @@
+// #include support
+
+int bar() { return foo(); }


### PR DESCRIPTION
The most interesting bit of this change is that rudimentary `typedef` declarations now work (at least, my one test case passes). I made a lot of simple refactorings before pushing through this change, most of which are continuing to unify the way that declarations are represented so that we can have more freedom to have any kind of declaration in any kind of context.