### PR TITLE
Fixup for `typedef` change.

### DIFF
--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -543,7 +543,6 @@ namespace Spire
 			return (BaseType == Compiler::BaseType::Int || BaseType == Compiler::BaseType::UInt || BaseType == Compiler::BaseType::Bool);
 		}
 
-
         bool ExpressionType::IsIntegral() const
         {
             return GetCanonicalType()->IsIntegralImpl();
@@ -657,6 +656,7 @@ namespace Spire
 		RefPtr<ExpressionType> ExpressionType::Float4;
 		RefPtr<ExpressionType> ExpressionType::Void;
 		RefPtr<ExpressionType> ExpressionType::Error;
+        List<RefPtr<ExpressionType>> ExpressionType::sCanonicalTypes;
 
 		void ExpressionType::Init()
 		{
@@ -693,6 +693,8 @@ namespace Spire
 			Float4 = nullptr;
 			Void = nullptr;
 			Error = nullptr;
+            // Note(tfoley): This seems to be just about the only way to clear out a List<T>
+            sCanonicalTypes = List<RefPtr<ExpressionType>>();
 		}
 		bool ArrayExpressionType::IsArrayImpl() const
 		{
@@ -709,6 +711,7 @@ namespace Spire
         {
             auto canonicalBaseType = BaseType->GetCanonicalType();
             auto canonicalArrayType = new ArrayExpressionType();
+            sCanonicalTypes.Add(canonicalArrayType);
             canonicalArrayType->BaseType = canonicalBaseType;
             canonicalArrayType->ArrayLength = ArrayLength;
             return canonicalArrayType;
@@ -745,6 +748,7 @@ namespace Spire
         {
             auto canonicalBaseType = BaseType->GetCanonicalType();
             auto canonicalGenericType = new GenericExpressionType();
+            sCanonicalTypes.Add(canonicalGenericType);
             canonicalGenericType->BaseType = canonicalBaseType;
             canonicalGenericType->GenericTypeName = GenericTypeName;
             return canonicalGenericType;

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -113,7 +113,7 @@ namespace Spire
         class TypeDefDecl;
         class NamedExpressionType;
 
-		class ExpressionType : public Object
+		class ExpressionType : public RefObject
 		{
 		public:
 			static RefPtr<ExpressionType> Bool;
@@ -131,6 +131,9 @@ namespace Spire
 			static RefPtr<ExpressionType> Float4;
 			static RefPtr<ExpressionType> Void;
 			static RefPtr<ExpressionType> Error;
+            // Note: just exists to make sure we can clean up
+            // canonical types we create along the way
+            static List<RefPtr<ExpressionType>> sCanonicalTypes;
 		public:
 			virtual String ToString() const = 0;
 			virtual ExpressionType * Clone() = 0;


### PR DESCRIPTION
The "canonical types" being created in that change weren't being cleaned up. Doing so isn't as trivial as making them use RefPtr<T> because a type might be its own canonical type and we don't want to introduce self-reference. Similarly, issues can arise if we are a named wrapper around a canonical type (we can't free our canonical type either, because somebody else might reference is).

The fix here is simplistic and a bit silly. Part (1) is making `ExpressionType` use `RefObject` so that it has an internal refcount (so we can recover a `RefPtr` from a raw pointer, if we ever want to) and part (2) was storing a global (static) list of all expression types created as part of canonicalization so that we can free them.

All of this would go away if we used some kind of pool to allocate these types.