### PR TITLE
Fix up tests, and parser error recovery

### DIFF
--- a/Source/SpireCore/DiagnosticDefs.h
+++ b/Source/SpireCore/DiagnosticDefs.h
@@ -98,17 +98,20 @@ DIAGNOSTIC(15901, Warning,  userDefinedWarning, "#warning: $0")
 // 2xxxx - Parsing
 //
 
+DIAGNOSTIC(20003, Error, unexpectedToken, "unexpected $0");
+DIAGNOSTIC(20001, Error, unexpectedTokenExpectedTokenType, "unexpected $0, expected $1");
+DIAGNOSTIC(20001, Error, unexpectedTokenExpectedTokenName, "unexpected $0, expected '$1'");
+
 DIAGNOSTIC(0, Error, tokenNameExpectedButEOF, "\"$0\" expected but end of file encountered.");
 DIAGNOSTIC(0, Error, tokenTypeExpectedButEOF, "$0 expected but end of file encountered.");
 DIAGNOSTIC(20001, Error, tokenNameExpected, "\"$0\" expected");
 DIAGNOSTIC(20001, Error, tokenNameExpectedButEOF2, "\"$0\" expected but end of file encountered.");
 DIAGNOSTIC(20001, Error, tokenTypeExpected, "$0 expected");
 DIAGNOSTIC(20001, Error, tokenTypeExpectedButEOF2, "$0 expected but end of file encountered.");
-DIAGNOSTIC(20001, Error, typeNameExpectedBut, "type name expected but '$0' encountered.");
+DIAGNOSTIC(20001, Error, typeNameExpectedBut, "unexpected $0, expected type name");
 DIAGNOSTIC(20001, Error, typeNameExpectedButEOF, "type name expected but end of file encountered.");
 DIAGNOSTIC(20001, Error, unexpectedEOF, " Unexpected end of file.");
 DIAGNOSTIC(20002, Error, syntaxError, "syntax error.");
-DIAGNOSTIC(20003, Error, unexpectedToken, "unexpected token '$0'.");
 DIAGNOSTIC(20004, Error, unexpectedTokenExpectedComponentDefinition, "unexpected token '$0', only component definitions are allowed in a shader scope.")
 DIAGNOSTIC(20008, Error, invalidOperator, "invalid operator '$0'.");
 DIAGNOSTIC(20011, Error, unexpectedColon, "unexpected ':'.")

--- a/Tests/Diagnostics/expected-token-eof.spire.expected
+++ b/Tests/Diagnostics/expected-token-eof.spire.expected
@@ -1,9 +1,6 @@
 result code = -1
 standard error = {
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: '?' expected but end of file encountered.
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: ',' expected but end of file encountered.
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: ';' expected but end of file encountered.
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: '}' expected but end of file encountered.
+Tests/Diagnostics/expected-token-eof.spire(0): error 20001: unexpected end of file, expected ';'
 }
 standard output = {
 }

--- a/Tests/Diagnostics/expected-token.spire.expected
+++ b/Tests/Diagnostics/expected-token.spire.expected
@@ -1,7 +1,6 @@
 result code = -1
 standard error = {
-Tests/Diagnostics/expected-token.spire(5): error 20001: ';' expected
-Tests/Diagnostics/expected-token.spire(5): error 20002: syntax error.
+Tests/Diagnostics/expected-token.spire(5): error 20001: unexpected ']', expected ';'
 }
 standard output = {
 }

--- a/Tests/Diagnostics/missing-file.spire.expected
+++ b/Tests/Diagnostics/missing-file.spire.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-Tests/Diagnostics/missing-file.spire(0): error 20001: ';' expected but end of file encountered.
+Tests/Diagnostics/missing-file.spire(0): error 20001: unexpected end of file, expected ';'
 Tests/Diagnostics/missing-file.spire(3): error 2: cannot find file 'Tests/Diagnostics/missing-file.spire'.
 }
 standard output = {

--- a/Tests/FrontEnd/parser-error-unclosed-curly.spire.expected
+++ b/Tests/FrontEnd/parser-error-unclosed-curly.spire.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-Tests/FrontEnd/parser-error-unclosed-curly.spire(0): error 20001: '}' expected but end of file encountered.
+Tests/FrontEnd/parser-error-unclosed-curly.spire(0): error 20001: unexpected end of file, expected '}'
 }
 standard output = {
 }

--- a/Tests/FrontEnd/pipeline-simple.spireh
+++ b/Tests/FrontEnd/pipeline-simple.spireh
@@ -8,53 +8,10 @@ pipeline StandardPipeline
     [Pinned]
     input world MeshVertex;
     
-    [Pinned]
-    input world ModelInstance;
-    
-    [Pinned]
-    
-    input world ViewUniform;
-    
-    [Pinned]
-    input world MaterialUniform;
-    
     world CoarseVertex;// : "glsl(vertex:projCoord)" using projCoord export standardExport;
     world Fragment;// : "glsl" export fragmentExport;
     
     require @CoarseVertex vec4 projCoord; 
-    
-    [Binding: "2"]
-    extern @(CoarseVertex*, Fragment*) Uniform<MaterialUniform> MaterialUniformBlock; 
-    import(MaterialUniform->CoarseVertex) uniformImport()
-    {
-        return project(MaterialUniformBlock);
-    }
-    import(MaterialUniform->Fragment) uniformImport()
-    {
-        return project(MaterialUniformBlock);
-    }
-
-    [Binding: "1"]
-    extern @(CoarseVertex*, Fragment*) Uniform<ViewUniform> ViewUniformBlock;
-    import(ViewUniform->CoarseVertex) uniformImport()
-    {
-        return project(ViewUniformBlock);
-    }
-    import(ViewUniform->Fragment) uniformImport()
-    {
-        return project(ViewUniformBlock);
-    }
-    
-    [Binding: "0"]
-    extern @(CoarseVertex*, Fragment*) Uniform<ModelInstance> ModelInstanceBlock;
-    import(ModelInstance->CoarseVertex) uniformImport()
-    {
-        return project(ModelInstanceBlock);
-    }
-    import(ModelInstance->Fragment) uniformImport()
-    {
-        return project(ModelInstanceBlock);
-    }
     
     [VertexInput]
     extern @CoarseVertex MeshVertex vertAttribIn;

--- a/Tests/FrontEnd/struct.spire
+++ b/Tests/FrontEnd/struct.spire
@@ -22,12 +22,12 @@ Foo makeFoo(float x, float y)
 shader Test : StandardPipeline
 {
 	// Uniform of struct type
-	@MaterialUniform Foo foo1;
+	param Foo foo1;
 
     @MeshVertex vec3 position;
     @MeshVertex vec3 color;
 
-    @ModelInstance mat4 modelViewProjection;
+    param mat4 modelViewProjection;
 
     public vec4 projCoord = modelViewProjection * vec4(position, 1.0);
 


### PR DESCRIPTION
Two changes here:

- Fix up the tests for the recent change to add `param`
- Change error recovery strategy in the parser to not use exceptions.

The latter change is the main one, and it is likely that there are still some issues in there. For the cases covered in our tests, however, the new strategy either produces the same error messages (modulo me re-wording the diagnostic message), or actually produces *better* diagnostics (fewer spurious messages).