### PR TITLE
Modifiers

### DIFF
--- a/Source/SpireCore/Closure.cpp
+++ b/Source/SpireCore/Closure.cpp
@@ -12,8 +12,8 @@ namespace Spire
 			{
 				RefPtr<ShaderComponentSymbol> ccomp;
 				RefPtr<ShaderClosure> su;
-				if ((comp.Value->Implementations.First()->SyntaxNode->IsPublic ||
-					comp.Value->Implementations.First()->SyntaxNode->IsOutput))
+				if ((comp.Value->Implementations.First()->SyntaxNode->IsPublic() ||
+					comp.Value->Implementations.First()->SyntaxNode->IsOutput()))
 				{
                     if (parent->Components.TryGetValue(comp.Key, ccomp))
                     {
@@ -123,7 +123,7 @@ namespace Spire
 							}
 						}
 						auto refClosure = CreateShaderClosure(err, symTable, shaderSym.Ptr(), import->Position, rootShader, refMap);
-						refClosure->IsPublic = import->IsPublic;
+						refClosure->IsPublic = import->IsPublic();
 						refClosure->Parent = rs.Ptr();
 						if (import->IsInplace)
 						{
@@ -151,7 +151,7 @@ namespace Spire
 			// check for unassigned arguments
 			for (auto & comp : shader->Components)
 			{
-				if (comp.Value->Implementations.First()->SyntaxNode->IsRequire &&
+				if (comp.Value->Implementations.First()->SyntaxNode->IsRequire() &&
 					!pRefMap.ContainsKey(comp.Key))
 				{
                     err->diagnose(rs->UsingPosition, Diagnostics::parameterOfModuleIsUnassigned, comp.Key, shader->SyntaxNode->Name);
@@ -330,7 +330,7 @@ namespace Spire
 				{
 					if (auto comp = shaderClosure->FindComponent(var->Type->AsBasicType()->Component->Name))
 					{
-						if (comp->Implementations.First()->SyntaxNode->IsRequire)
+						if (comp->Implementations.First()->SyntaxNode->IsRequire())
 							shaderClosure->RefMap.TryGetValue(comp->Name, comp);
 						var->Tags["ComponentReference"] = new StringObject(comp->UniqueName);
 						AddReference(comp.Ptr(), currentImport, var->Position);
@@ -340,7 +340,7 @@ namespace Spire
 				}
 				if (auto comp = shaderClosure->FindComponent(var->Variable))
 				{
-					if (comp->Implementations.First()->SyntaxNode->IsRequire)
+					if (comp->Implementations.First()->SyntaxNode->IsRequire())
 						shaderClosure->RefMap.TryGetValue(var->Variable, comp);
 					var->Tags["ComponentReference"] = new StringObject(comp->UniqueName);
 
@@ -450,7 +450,7 @@ namespace Spire
 
 		bool IsInAbstractWorld(PipelineSymbol * pipeline, ShaderComponentSymbol* comp)
 		{
-			return comp->Implementations.First()->Worlds.Count() && !comp->Implementations.First()->SyntaxNode->IsRequire &&
+			return comp->Implementations.First()->Worlds.Count() && !comp->Implementations.First()->SyntaxNode->IsRequire() &&
 				pipeline->IsAbstractWorld(comp->Implementations.First()->Worlds.First());
 		}
 
@@ -465,7 +465,7 @@ namespace Spire
 				else
 				{
 					String uniqueChoiceName;
-					if (comp.Value->Implementations.First()->SyntaxNode->IsPublic)
+					if (comp.Value->Implementations.First()->SyntaxNode->IsPublic())
 						uniqueChoiceName = publicNamePrefix + comp.Key;
 					else
 						uniqueChoiceName = namePrefix + comp.Key;
@@ -541,7 +541,7 @@ namespace Spire
 		bool IsWorldFeasible(SymbolTable * symTable, PipelineSymbol * pipeline, ShaderComponentImplSymbol * impl, String world, ShaderComponentSymbol*& unaccessibleComp)
 		{
 			// shader parameter (uniform values) are available to all worlds
-			if (impl->SyntaxNode->IsParam)
+			if (impl->SyntaxNode->IsParam())
 				return true;
 			bool isWFeasible = true;
 			for (auto & dcomp : impl->DependentComponents)
@@ -765,7 +765,7 @@ namespace Spire
 
 				if (comp.Value.Symbol->Implementations.Count() == 1 &&
 					comp.Value.Symbol->Implementations.First()->SyntaxNode->Expression &&
-					!comp.Value.Symbol->Implementations.First()->SyntaxNode->IsOutput)
+					!comp.Value.Symbol->Implementations.First()->SyntaxNode->IsOutput())
 				{
 					RefPtr<Object> compRef;
 					if (comp.Value.Symbol->Implementations.First()->SyntaxNode->Expression->Tags.TryGetValue("ComponentReference", compRef))
@@ -864,7 +864,7 @@ namespace Spire
 							WorldSyntaxNode* worldDecl;
 							if (shader->Pipeline->Worlds.TryGetValue(world.World.Content, worldDecl))
 							{
-								if (worldDecl->IsAbstract)
+								if (worldDecl->IsAbstract())
 								{
 									inAbstractWorld = true;
 									if (userSpecifiedWorlds.Count() > 1)
@@ -876,7 +876,7 @@ namespace Spire
 							}
 						}
 					}
-					if (!inAbstractWorld && !impl->SyntaxNode->IsRequire && !impl->SyntaxNode->IsInput && !impl->SyntaxNode->IsParam
+					if (!inAbstractWorld && !impl->SyntaxNode->IsRequire() && !impl->SyntaxNode->IsInput() && !impl->SyntaxNode->IsParam()
 						&& !impl->SyntaxNode->Expression && !impl->SyntaxNode->BlockStatement)
 					{
 						err->diagnose(impl->SyntaxNode->Position, Diagnostics::nonAbstractComponentMustHaveImplementation);
@@ -890,7 +890,7 @@ namespace Spire
 							auto world = shader->Pipeline->Worlds.TryGetValue(w.World.Content);
 							if (world)
 							{
-								if ((*world)->IsAbstract)
+								if ((*world)->IsAbstract())
 									isDefinedInAbstractWorld = true;
 								else
 									isDefinedInNonAbstractWorld = true;

--- a/Source/SpireCore/DiagnosticDefs.h
+++ b/Source/SpireCore/DiagnosticDefs.h
@@ -98,17 +98,20 @@ DIAGNOSTIC(15901, Warning,  userDefinedWarning, "#warning: $0")
 // 2xxxx - Parsing
 //
 
+DIAGNOSTIC(20003, Error, unexpectedToken, "unexpected $0");
+DIAGNOSTIC(20001, Error, unexpectedTokenExpectedTokenType, "unexpected $0, expected $1");
+DIAGNOSTIC(20001, Error, unexpectedTokenExpectedTokenName, "unexpected $0, expected '$1'");
+
 DIAGNOSTIC(0, Error, tokenNameExpectedButEOF, "\"$0\" expected but end of file encountered.");
 DIAGNOSTIC(0, Error, tokenTypeExpectedButEOF, "$0 expected but end of file encountered.");
 DIAGNOSTIC(20001, Error, tokenNameExpected, "\"$0\" expected");
 DIAGNOSTIC(20001, Error, tokenNameExpectedButEOF2, "\"$0\" expected but end of file encountered.");
 DIAGNOSTIC(20001, Error, tokenTypeExpected, "$0 expected");
 DIAGNOSTIC(20001, Error, tokenTypeExpectedButEOF2, "$0 expected but end of file encountered.");
-DIAGNOSTIC(20001, Error, typeNameExpectedBut, "type name expected but '$0' encountered.");
+DIAGNOSTIC(20001, Error, typeNameExpectedBut, "unexpected $0, expected type name");
 DIAGNOSTIC(20001, Error, typeNameExpectedButEOF, "type name expected but end of file encountered.");
 DIAGNOSTIC(20001, Error, unexpectedEOF, " Unexpected end of file.");
 DIAGNOSTIC(20002, Error, syntaxError, "syntax error.");
-DIAGNOSTIC(20003, Error, unexpectedToken, "unexpected token '$0'.");
 DIAGNOSTIC(20004, Error, unexpectedTokenExpectedComponentDefinition, "unexpected token '$0', only component definitions are allowed in a shader scope.")
 DIAGNOSTIC(20008, Error, invalidOperator, "invalid operator '$0'.");
 DIAGNOSTIC(20011, Error, unexpectedColon, "unexpected ':'.")

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -106,9 +106,7 @@ namespace Spire
 			bool LookAheadToken(CoreLib::Text::TokenType type, int offset = 0);
 			bool LookAheadToken(const char * string, int offset = 0);
 			Token ReadTypeKeyword();
-			VariableModifier ReadVariableModifier();
 			bool IsTypeKeyword();
-			EnumerableDictionary<String, String>	ParseAttribute();
 			RefPtr<ProgramSyntaxNode>				ParseProgram();
 			RefPtr<ShaderSyntaxNode>				ParseShader();
 			RefPtr<PipelineSyntaxNode>				ParsePipeline();
@@ -505,25 +503,6 @@ namespace Spire
 			return ParseProgram();
 		}
 
-		EnumerableDictionary<String, String> Parser::ParseAttribute()
-		{
-			EnumerableDictionary<String, String> rs;
-			while (LookAheadToken(TokenType::LBracket))
-			{
-				ReadToken(TokenType::LBracket);
-				auto name = ReadToken(TokenType::Identifier).Content;
-				String value;
-				if (LookAheadToken(TokenType::Colon))
-				{
-					ReadToken(TokenType::Colon);
-					value = ReadToken(TokenType::StringLiterial).Content;
-				}
-				rs[name] = value;
-				ReadToken(TokenType::RBracket);
-			}
-			return rs;
-		}
-
         RefPtr<TypeDefDecl> ParseTypeDef(Parser* parser)
         {
             // Consume the `typedef` keyword
@@ -634,6 +613,122 @@ namespace Spire
 			return shader;
 		}
 
+        static Modifiers ParseModifiers(Parser* parser)
+        {
+            Modifiers modifiers;
+            RefPtr<Modifier>* modifierLink = &modifiers.first;
+            for (;;)
+            {
+                if (AdvanceIf(parser, "in"))
+                {
+                    modifiers.flags |= ModifierFlag::In;
+                }
+                else if (AdvanceIf(parser, "input"))
+                {
+                    modifiers.flags |= ModifierFlag::Input;
+                }
+                else if (AdvanceIf(parser, "out"))
+                {
+                    modifiers.flags |= ModifierFlag::Out;
+                }
+                else if (AdvanceIf(parser, "uniform"))
+                {
+                    modifiers.flags |= ModifierFlag::Uniform;
+                }
+                else if (AdvanceIf(parser, "parameter"))
+                {
+                    modifiers.flags |= ModifierFlag::Parameter;
+                }
+                else if (AdvanceIf(parser, "const"))
+                {
+                    modifiers.flags |= ModifierFlag::Const;
+                }
+                else if (AdvanceIf(parser, "centroid"))
+                {
+                    modifiers.flags |= ModifierFlag::Centroid;
+                }
+                else if (AdvanceIf(parser, "instance"))
+                {
+                    modifiers.flags |= ModifierFlag::Instance;
+                }
+                else if (AdvanceIf(parser, "__builtin"))
+                {
+                    modifiers.flags |= ModifierFlag::Builtin;
+                }
+                else if (AdvanceIf(parser, "layout"))
+				{
+					parser->ReadToken(TokenType::LParent);
+					StringBuilder layoutSB;
+					while (!AdvanceIfMatch(parser, TokenType::RParent))
+					{
+						layoutSB.Append(parser->ReadToken(TokenType::Identifier).Content);
+						if (parser->LookAheadToken(TokenType::OpAssign))
+						{
+							layoutSB.Append(parser->ReadToken(TokenType::OpAssign).Content);
+							layoutSB.Append(parser->ReadToken(TokenType::IntLiterial).Content);
+						}
+						if (AdvanceIf(parser, TokenType::RParent))
+							break;
+						parser->ReadToken(TokenType::Comma);
+						layoutSB.Append(", ");
+					}
+
+                    RefPtr<LayoutModifier> modifier = new LayoutModifier();
+                    modifier->LayoutString = layoutSB.ProduceString();
+
+                    *modifierLink = modifier;
+                    modifierLink = &modifier->next;
+				}
+                else if (AdvanceIf(parser, "inline"))
+				{
+					modifiers.flags |= ModifierFlag::Inline;
+				}
+				else if (AdvanceIf(parser, "public"))
+				{
+					modifiers.flags |= ModifierFlag::Public;
+				}
+				else if (AdvanceIf(parser, "require"))
+				{
+					modifiers.flags |= ModifierFlag::Require;
+				}
+				else if (AdvanceIf(parser, "param"))
+				{
+					modifiers.flags |= ModifierFlag::Param;
+				}
+				else if (AdvanceIf(parser, "extern"))
+				{
+					modifiers.flags |= ModifierFlag::Extern;
+				}
+                else if (AdvanceIf(parser, TokenType::LBracket))
+                {
+                    auto name = parser->ReadToken(TokenType::Identifier).Content;
+                    String value;
+                    if (AdvanceIf(parser, TokenType::Colon))
+                    {
+                        value = parser->ReadToken(TokenType::StringLiterial).Content;
+                    }
+                    parser->ReadToken(TokenType::RBracket);
+
+                    RefPtr<SimpleAttribute> modifier = new SimpleAttribute();
+                    modifier->Key = name;
+                    modifier->Value = value;
+
+                    *modifierLink = modifier;
+                    modifierLink = &modifier->next;
+                }
+                else if (AdvanceIf(parser, "__intrinsic"))
+                {
+                    modifiers.flags |= ModifierFlag::Intrinsic;
+                }
+                else
+                {
+                    // Done with modifier list
+                    return modifiers;
+                }
+            }
+        }
+
+
 		RefPtr<PipelineSyntaxNode> Parser::ParsePipeline()
 		{
 			RefPtr<PipelineSyntaxNode> pipeline = new PipelineSyntaxNode();
@@ -648,17 +743,17 @@ namespace Spire
 			ReadToken(TokenType::LBrace);
 			while (!AdvanceIfMatch(this, TokenType::RBrace))
 			{
-				auto attribs = ParseAttribute();
+                auto modifiers = ParseModifiers(this);
 				if (LookAheadToken("input") || LookAheadToken("world"))
 				{
 					auto w = ParseWorld();
-					w->LayoutAttributes = attribs;
+					w->modifiers = modifiers;
 					pipeline->Members.Add(w);
 				}
 				else if (LookAheadToken("import"))
 				{
 					auto op = ParseImportOperator();
-					op->LayoutAttributes = attribs;
+					op->modifiers = modifiers;
 					pipeline->Members.Add(op);
 				}
 				else if (LookAheadToken("stage"))
@@ -668,7 +763,7 @@ namespace Spire
 				else
 				{
 					auto comp = ParseComponent();
-					comp->LayoutAttributes = attribs;
+					comp->modifiers = modifiers;
 					pipeline->Members.Add(comp);
 				}
 			}
@@ -704,38 +799,7 @@ namespace Spire
 		{
 			RefPtr<ComponentSyntaxNode> component = new ComponentSyntaxNode();
 			PushScope();
-			component->LayoutAttributes = ParseAttribute();
-			while (LookAheadToken("inline") || LookAheadToken("out") || LookAheadToken("require") || LookAheadToken("public") ||
-				LookAheadToken("extern") || LookAheadToken("param"))
-			{
-				if (AdvanceIf(this, "inline"))
-				{
-					component->IsInline = true;
-				}
-				else if (AdvanceIf(this, "out"))
-				{
-					component->IsOutput = true;
-				}
-				else if (AdvanceIf(this, "public"))
-				{
-					component->IsPublic = true;
-				}
-				else if (AdvanceIf(this, "require"))
-				{
-					component->IsRequire = true;
-				}
-				else if (AdvanceIf(this, "param"))
-				{
-					component->IsParam = true;
-					component->IsPublic = true;
-				}
-				else if (AdvanceIf(this, "extern"))
-				{
-					component->IsInput = true;
-				}
-				else
-					break;
-			}
+            component->modifiers = ParseModifiers(this);
 			if (LookAheadToken(TokenType::At))
 				component->Rate = ParseRate();
 			component->TypeNode = ParseType();
@@ -773,8 +837,7 @@ namespace Spire
 		RefPtr<WorldSyntaxNode> Parser::ParseWorld()
 		{
 			RefPtr<WorldSyntaxNode> world = new WorldSyntaxNode();
-			world->LayoutAttributes = ParseAttribute();
-			world->IsAbstract = AdvanceIf(this, "input");
+            world->modifiers = ParseModifiers(this);
 			ReadToken("world");
 			FillPosition(world.Ptr());
 			world->Name = ReadToken(TokenType::Identifier);
@@ -816,10 +879,7 @@ namespace Spire
 		RefPtr<ImportSyntaxNode> Parser::ParseImport()
 		{
 			RefPtr<ImportSyntaxNode> rs = new ImportSyntaxNode();
-			if (AdvanceIf(this, "public"))
-			{
-				rs->IsPublic = true;
-			}
+            rs->modifiers = ParseModifiers(this);
 			ReadToken("using");
 			rs->IsInplace = !LookAheadToken(TokenType::OpAssign, 1);
 			if (!rs->IsInplace)
@@ -920,25 +980,7 @@ namespace Spire
 		{
 			anonymousParamCounter = 0;
 			RefPtr<FunctionSyntaxNode> function = new FunctionSyntaxNode();
-			if (LookAheadToken("__intrinsic"))
-			{
-				function->HasSideEffect = false;
-				function->IsExtern = true;
-                tokenReader.AdvanceToken();
-			}
-			else if (LookAheadToken("extern"))
-			{
-				function->IsExtern = true;
-                tokenReader.AdvanceToken();
-			}
-			else
-				function->IsExtern = false;
-			function->IsInline = true;
-			if (LookAheadToken("inline"))
-			{
-				function->IsInline = true;
-                tokenReader.AdvanceToken();
-			}
+            function->modifiers = ParseModifiers(this);
 			
 			PushScope();
 			function->ReturnTypeNode = ParseType();
@@ -976,7 +1018,7 @@ namespace Spire
 			}
 			if (parseBody)
 			{
-				if (!function->IsExtern)
+				if (!function->IsExtern())
 					function->Body = ParseBlockStatement();
 				else
 					ReadToken(TokenType::Semicolon);
@@ -1100,28 +1142,6 @@ namespace Spire
 			return blockStatement;
 		}
 
-		VariableModifier Parser::ReadVariableModifier()
-		{
-			auto token = ReadToken(TokenType::Identifier);
-			if (token.Content == "in")
-				return VariableModifier::In;
-			else if (token.Content == "out")
-				return VariableModifier::Out;
-			else if (token.Content == "uniform")
-				return VariableModifier::Uniform;
-			else if (token.Content == "parameter")
-				return VariableModifier::Parameter;
-			else if (token.Content == "const")
-				return VariableModifier::Const;
-			else if (token.Content == "centroid")
-				return VariableModifier::Centroid;
-			else if (token.Content == "instance")
-				return VariableModifier::Instance;
-			else if (token.Content == "__builtin")
-				return VariableModifier::Builtin;
-			return VariableModifier::None; 
-		}
-
         static RefPtr<Decl> ParseLocalVarDecls(Parser* parser)
         {
             // TODO(tfoley): it is wasteful to allocate this if
@@ -1129,32 +1149,8 @@ namespace Spire
             RefPtr<MultiDecl> multiDecl = new MultiDecl();
 		
 			parser->FillPosition(multiDecl.Ptr());
-			while (!parser->tokenReader.IsAtEnd())
-			{
-				if (parser->LookAheadToken("layout"))
-				{
-					parser->ReadToken("layout");
-					parser->ReadToken(TokenType::LParent);
-					StringBuilder layoutSB;
-					while (!parser->LookAheadToken(TokenType::RParent))
-					{
-						layoutSB.Append(parser->ReadToken(TokenType::Identifier).Content);
-						if (parser->LookAheadToken(TokenType::OpAssign))
-						{
-							layoutSB.Append(parser->ReadToken(TokenType::OpAssign).Content);
-							layoutSB.Append(parser->ReadToken(TokenType::IntLiterial).Content);
-						}
-						if (!parser->LookAheadToken(TokenType::Comma))
-							break;
-						else
-							layoutSB.Append(", ");
-					}
-					parser->ReadToken(TokenType::RParent);
-					multiDecl->LayoutString = layoutSB.ProduceString();
-				}
-				else
-					break;
-			}
+
+            multiDecl->modifiers = ParseModifiers(parser);
 			multiDecl->TypeNode = parser->ParseType();
 			while (!parser->tokenReader.IsAtEnd())
 			{
@@ -1311,28 +1307,7 @@ namespace Spire
 		RefPtr<ParameterSyntaxNode> Parser::ParseParameter()
 		{
 			RefPtr<ParameterSyntaxNode> parameter = new ParameterSyntaxNode();
-			if (LookAheadToken("in"))
-			{
-				parameter->Qualifier = ParameterQualifier::In;
-				ReadToken("in");
-			}
-			else if (LookAheadToken("inout"))
-			{
-				parameter->Qualifier = ParameterQualifier::InOut;
-				ReadToken("inout");
-			}
-			else if (LookAheadToken("out"))
-			{
-				parameter->Qualifier = ParameterQualifier::Out;
-				ReadToken("out");
-			}
-			else if (LookAheadToken("uniform"))
-			{
-				parameter->Qualifier = ParameterQualifier::Uniform;
-				ReadToken("uniform");
-				if (LookAheadToken("in"))
-					ReadToken("in");
-			}
+            parameter->modifiers = ParseModifiers(this);
 			parameter->TypeNode = ParseType();
 			if (LookAheadToken(TokenType::Identifier))
 			{

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -277,7 +277,7 @@ namespace Spire
 				for (auto comp : pipeline->GetAbstractComponents())
 				{
 					comp->Type = TranslateTypeNode(comp->TypeNode);
-					if (comp->IsRequire || comp->IsInput || (comp->Rate && comp->Rate->Worlds.Count() == 1
+					if (comp->IsRequire() || comp->IsInput() || (comp->Rate && comp->Rate->Worlds.Count() == 1
 						&& psymbol->IsAbstractWorld(comp->Rate->Worlds.First().World.Content)))
 						AddNewComponentSymbol(psymbol->Components, psymbol->FunctionComponents, comp);
                     else
@@ -296,7 +296,7 @@ namespace Spire
 						getSink()->diagnose(op->DestWorld, Diagnostics::undefinedWorldName, op->DestWorld.Content);
 					else
 					{
-						if (psymbol->Worlds[op->DestWorld.Content].GetValue()->IsAbstract)
+						if (psymbol->Worlds[op->DestWorld.Content].GetValue()->IsAbstract())
 							getSink()->diagnose(op->DestWorld, Diagnostics::abstractWorldAsTargetOfImport);
 						else if (!psymbol->WorldDependency.ContainsKey(op->SourceWorld.Content))
 							getSink()->diagnose(op->SourceWorld, Diagnostics::undefinedWorldName2, op->SourceWorld.Content);
@@ -481,19 +481,15 @@ namespace Spire
 					currentShader->Components.TryGetValue(comp->Name.Content, compSym);
 					currentComp = compSym.Ptr();
 					SyntaxVisitor::VisitComponent(comp);
-					if (comp->Parameters.Count() > 0)
-					{
-						comp->IsInline = true;
-					}
 					if (comp->Expression || comp->BlockStatement)
 					{
 						if (compSym->IsRequire())
 							getSink()->diagnose(comp, Diagnostics::requireWithComputation);
-						if (comp->IsParam)
+						if (comp->IsParam())
 							getSink()->diagnose(comp, Diagnostics::paramWithComputation);
 					}
-					if (compSym->Type->DataType->GetBindableResourceType() != BindableResourceType::NonBindable && !comp->IsParam
-						&& !comp->IsRequire)
+					if (compSym->Type->DataType->GetBindableResourceType() != BindableResourceType::NonBindable && !comp->IsParam()
+						&& !comp->IsRequire())
 						getSink()->diagnose(comp, Diagnostics::resourceTypeMustBeParamOrRequire, comp->Name);
 					currentComp = nullptr;
 					return comp;
@@ -509,7 +505,7 @@ namespace Spire
 					{
 						ShaderUsing su;
 						su.Shader = refShader.Ptr();
-						su.IsPublic = import->IsPublic;
+						su.IsPublic = import->IsPublic();
 						if (import->IsInplace)
 						{
 							currentShader->ShaderUsings.Add(su);
@@ -575,7 +571,7 @@ namespace Spire
 					if (auto comp = dynamic_cast<ComponentSyntaxNode*>(mbr.Ptr()))
 					{
 						comp->Type = TranslateTypeNode(comp->TypeNode);
-						if (comp->IsRequire)
+						if (comp->IsRequire())
 						{
 							shaderSymbol->IsAbstract = true;
 							if (!shaderSymbol->SyntaxNode->IsModule)
@@ -725,7 +721,7 @@ namespace Spire
 				{
 					compImpl->AlternateName = compImpl->SyntaxNode->AlternateName.Content;
 				}
-				if (compImpl->SyntaxNode->IsOutput)
+				if (compImpl->SyntaxNode->IsOutput())
 				{
 					if (compImpl->SyntaxNode->Rate)
 					{
@@ -750,7 +746,7 @@ namespace Spire
 				}
 				else
 				{
-					if (comp->IsRequire)
+					if (comp->IsRequire())
 						getSink()->diagnose(compImpl->SyntaxNode.Ptr(), Diagnostics::requirementsClashWithPreviousDef, compImpl->SyntaxNode->Name.Content);
 					else
 					{
@@ -878,7 +874,7 @@ namespace Spire
 
 			virtual RefPtr<FunctionSyntaxNode> VisitFunction(FunctionSyntaxNode *functionNode) override
 			{
-				if (!functionNode->IsExtern)
+				if (!functionNode->IsExtern())
 				{
 					currentFunc = symbolTable->Functions.TryGetValue(functionNode->InternalName)->Ptr();
 					this->function = functionNode;
@@ -1462,7 +1458,7 @@ namespace Spire
 				}
 				if (func)
 				{
-					if (!func->SyntaxNode->IsExtern)
+					if (!func->SyntaxNode->IsExtern())
 					{
 						varExpr->Variable = func->SyntaxNode->InternalName;
 						if (currentFunc)
@@ -1552,8 +1548,7 @@ namespace Spire
 						{
 							for (int i = 0; i < (*params).Count(); i++)
 							{
-								if ((*params)[i]->Qualifier == ParameterQualifier::Out ||
-									(*params)[i]->Qualifier == ParameterQualifier::InOut)
+								if ((*params)[i]->HasModifier(ModifierFlag::Out))
 								{
 									if (i < expr->Arguments.Count() && expr->Arguments[i]->Type->AsBasicType() &&
 										!expr->Arguments[i]->Type->AsBasicType()->IsLeftValue)

--- a/Source/SpireCore/SymbolTable.cpp
+++ b/Source/SpireCore/SymbolTable.cpp
@@ -142,7 +142,7 @@ namespace Spire
 		{
 			WorldSyntaxNode* worldDecl;
 			if (Worlds.TryGetValue(world, worldDecl))
-				return worldDecl->IsAbstract;
+				return worldDecl->IsAbstract();
 			return false;
 		}
 
@@ -294,7 +294,7 @@ namespace Spire
 			{
 				if (shaderUsing.Shader->Components.TryGetValue(compName, refComp))
 				{
-					if (refComp->Implementations.First()->SyntaxNode->IsPublic)
+					if (refComp->Implementations.First()->SyntaxNode->IsPublic())
 					{
 						result.Component = refComp.Ptr();
 						result.IsAccessible = true;
@@ -355,7 +355,7 @@ namespace Spire
 			}
 			for (auto & cimpl : comp->Implementations)
 			{
-				if (impl->SyntaxNode->IsOutput != cimpl->SyntaxNode->IsOutput)
+				if (impl->SyntaxNode->IsOutput() != cimpl->SyntaxNode->IsOutput())
 				{
                     err->diagnose(impl->SyntaxNode->Position,
                         Diagnostics::inconsistentSignatureForComponent,
@@ -365,7 +365,7 @@ namespace Spire
 					rs = false;
 					break;
 				}
-				if (impl->SyntaxNode->IsRequire != cimpl->SyntaxNode->IsRequire)
+				if (impl->SyntaxNode->IsRequire() != cimpl->SyntaxNode->IsRequire())
 				{
                     err->diagnose(impl->SyntaxNode->Position,
                         Diagnostics::inconsistentSignatureForComponent,
@@ -375,7 +375,7 @@ namespace Spire
 					rs = false;
 					break;
 				}
-				if (impl->SyntaxNode->IsPublic != cimpl->SyntaxNode->IsPublic)
+				if (impl->SyntaxNode->IsPublic() != cimpl->SyntaxNode->IsPublic())
 				{
                     err->diagnose(impl->SyntaxNode->Position,
                         Diagnostics::inconsistentSignatureForComponent,
@@ -396,7 +396,7 @@ namespace Spire
 					break;
 				}
 			}
-			if (impl->SyntaxNode->IsRequire && comp->Implementations.Count() != 0)
+			if (impl->SyntaxNode->IsRequire() && comp->Implementations.Count() != 0)
 			{
                 err->diagnose(impl->SyntaxNode->Position,
                     Diagnostics::parameterNameConflictsWithExistingDefinition, comp->Name);
@@ -539,7 +539,7 @@ namespace Spire
 				if (subClosure.Value->IsInPlace)
 				{
 					rs = subClosure.Value->FindComponent(name, findInPrivate, includeParams);
-					if (rs && (findInPrivate || rs->Implementations.First()->SyntaxNode->IsPublic))
+					if (rs && (findInPrivate || rs->Implementations.First()->SyntaxNode->IsPublic()))
 						return rs;
 					else
 						rs = nullptr;

--- a/Source/SpireCore/SymbolTable.h
+++ b/Source/SpireCore/SymbolTable.h
@@ -52,7 +52,7 @@ namespace Spire
 			bool IsRequire()
 			{
 				for (auto & impl : Implementations)
-					if (impl->SyntaxNode->IsRequire)
+					if (impl->SyntaxNode->IsRequire())
 						return true;
 				return false;
 			}

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -8,19 +8,49 @@ namespace Spire
 {
 	namespace Compiler
 	{
-    Decl* Scope::LookUp(String const& name)
-    {
-        Scope* scope = this;
-        while (scope)
-        {
-            Decl* decl = nullptr;
-            if (scope->decls.TryGetValue(name, decl))
-                return decl;
+        // Scope
 
-            scope = scope->Parent;
+        Decl* Scope::LookUp(String const& name)
+        {
+            Scope* scope = this;
+            while (scope)
+            {
+                Decl* decl = nullptr;
+                if (scope->decls.TryGetValue(name, decl))
+                    return decl;
+
+                scope = scope->Parent;
+            }
+            return nullptr;
         }
-        return nullptr;
-    }
+
+        // Decl
+
+        bool Decl::FindSimpleAttribute(String const& key, String& outValue)
+        {
+            for (auto attr : GetLayoutAttributes())
+            {
+                if (attr->Key == key)
+                {
+                    outValue = attr->Value;
+                    return true;
+                }
+            }
+            return false;
+        }
+        bool Decl::HasSimpleAttribute(String const& key)
+        {
+            for (auto attr : GetLayoutAttributes())
+            {
+                if (attr->Key == key)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        //
 
 		bool BasicExpressionType::EqualsImpl(const ExpressionType * type) const
 		{

--- a/Source/SpireLib/SpireLib.cpp
+++ b/Source/SpireLib/SpireLib.cpp
@@ -552,7 +552,7 @@ namespace SpireLib
 						compMeta.Offset = offset;
 						offset += compMeta.Size;
 						auto impl = comp.Value->Implementations.First();
-						if (impl->SyntaxNode->IsRequire)
+						if (impl->SyntaxNode->IsRequire())
 						{
 							meta.Requirements.Add(compMeta);
 						}

--- a/Tests/Diagnostics/expected-token-eof.spire.expected
+++ b/Tests/Diagnostics/expected-token-eof.spire.expected
@@ -1,9 +1,6 @@
 result code = -1
 standard error = {
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: '?' expected but end of file encountered.
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: ',' expected but end of file encountered.
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: ';' expected but end of file encountered.
-Tests/Diagnostics/expected-token-eof.spire(0): error 20001: '}' expected but end of file encountered.
+Tests/Diagnostics/expected-token-eof.spire(0): error 20001: unexpected end of file, expected ';'
 }
 standard output = {
 }

--- a/Tests/Diagnostics/expected-token.spire.expected
+++ b/Tests/Diagnostics/expected-token.spire.expected
@@ -1,7 +1,6 @@
 result code = -1
 standard error = {
-Tests/Diagnostics/expected-token.spire(5): error 20001: ';' expected
-Tests/Diagnostics/expected-token.spire(5): error 20002: syntax error.
+Tests/Diagnostics/expected-token.spire(5): error 20001: unexpected ']', expected ';'
 }
 standard output = {
 }

--- a/Tests/Diagnostics/missing-file.spire.expected
+++ b/Tests/Diagnostics/missing-file.spire.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-Tests/Diagnostics/missing-file.spire(0): error 20001: ';' expected but end of file encountered.
+Tests/Diagnostics/missing-file.spire(0): error 20001: unexpected end of file, expected ';'
 Tests/Diagnostics/missing-file.spire(3): error 2: cannot find file 'Tests/Diagnostics/missing-file.spire'.
 }
 standard output = {

--- a/Tests/FrontEnd/parser-error-unclosed-curly.spire.expected
+++ b/Tests/FrontEnd/parser-error-unclosed-curly.spire.expected
@@ -1,6 +1,6 @@
 result code = -1
 standard error = {
-Tests/FrontEnd/parser-error-unclosed-curly.spire(0): error 20001: '}' expected but end of file encountered.
+Tests/FrontEnd/parser-error-unclosed-curly.spire(0): error 20001: unexpected end of file, expected '}'
 }
 standard output = {
 }

--- a/Tests/FrontEnd/pipeline-simple.spireh
+++ b/Tests/FrontEnd/pipeline-simple.spireh
@@ -8,53 +8,10 @@ pipeline StandardPipeline
     [Pinned]
     input world MeshVertex;
     
-    [Pinned]
-    input world ModelInstance;
-    
-    [Pinned]
-    
-    input world ViewUniform;
-    
-    [Pinned]
-    input world MaterialUniform;
-    
     world CoarseVertex;// : "glsl(vertex:projCoord)" using projCoord export standardExport;
     world Fragment;// : "glsl" export fragmentExport;
     
     require @CoarseVertex vec4 projCoord; 
-    
-    [Binding: "2"]
-    extern @(CoarseVertex*, Fragment*) Uniform<MaterialUniform> MaterialUniformBlock; 
-    import(MaterialUniform->CoarseVertex) uniformImport()
-    {
-        return project(MaterialUniformBlock);
-    }
-    import(MaterialUniform->Fragment) uniformImport()
-    {
-        return project(MaterialUniformBlock);
-    }
-
-    [Binding: "1"]
-    extern @(CoarseVertex*, Fragment*) Uniform<ViewUniform> ViewUniformBlock;
-    import(ViewUniform->CoarseVertex) uniformImport()
-    {
-        return project(ViewUniformBlock);
-    }
-    import(ViewUniform->Fragment) uniformImport()
-    {
-        return project(ViewUniformBlock);
-    }
-    
-    [Binding: "0"]
-    extern @(CoarseVertex*, Fragment*) Uniform<ModelInstance> ModelInstanceBlock;
-    import(ModelInstance->CoarseVertex) uniformImport()
-    {
-        return project(ModelInstanceBlock);
-    }
-    import(ModelInstance->Fragment) uniformImport()
-    {
-        return project(ModelInstanceBlock);
-    }
     
     [VertexInput]
     extern @CoarseVertex MeshVertex vertAttribIn;

--- a/Tests/FrontEnd/struct.spire
+++ b/Tests/FrontEnd/struct.spire
@@ -22,12 +22,12 @@ Foo makeFoo(float x, float y)
 shader Test : StandardPipeline
 {
 	// Uniform of struct type
-	@MaterialUniform Foo foo1;
+	param Foo foo1;
 
     @MeshVertex vec3 position;
     @MeshVertex vec3 color;
 
-    @ModelInstance mat4 modelViewProjection;
+    param mat4 modelViewProjection;
 
     public vec4 projCoord = modelViewProjection * vec4(position, 1.0);
 


### PR DESCRIPTION
This builds on top of the preceding PR, so the diffs will look bigger than they really are.

The real change here is the last one, which unifies the representation of all modifiers on declarations in the AST, so that they can be parsed uniformly.

I plan to work on a follow-up change that takes advantage of this uniformity to streamline the parser further. If this PR doesn't get merged by then, I'll probably close it and make a larger unified PR.