### PR TITLE
Unify parser handling of declarations

### DIFF
--- a/Source/SpireCore/Closure.cpp
+++ b/Source/SpireCore/Closure.cpp
@@ -582,14 +582,10 @@ namespace Spire
 			auto depOrder = shader->GetDependencyOrder();
 			for (auto & comp : depOrder)
 			{
-				// automatically deduced overloadable worlds for a component definition without explicit rate qualifier
-				Dictionary<String, EnumerableHashSet<String>> autoWorlds; // keyed on alternate name 
 				comp->Type->FeasibleWorlds.Clear();
 				for (auto & impl : comp->Implementations)
 				{
-					if (!autoWorlds.ContainsKey(impl->AlternateName))
-						autoWorlds[impl->AlternateName] = allWorlds;
-					auto & autoWorld = autoWorlds[impl->AlternateName]();
+					auto & autoWorld = allWorlds;
 					for (auto & w : impl->Worlds)
 					{
 						ShaderComponentSymbol* unaccessibleComp = nullptr;
@@ -609,7 +605,7 @@ namespace Spire
 				{
 					if (impl->Worlds.Count() == 0) // if this component definition is not qualified with a world
 					{
-						EnumerableHashSet<String> deducedWorlds = autoWorlds[impl->AlternateName]();
+						EnumerableHashSet<String> deducedWorlds = allWorlds;
 						EnumerableHashSet<String> feasibleWorlds;
 						// the auto-deduced world for this definition is all feasible worlds in autoWorld.
 						for (auto & w : deducedWorlds)

--- a/Source/SpireCore/Closure.cpp
+++ b/Source/SpireCore/Closure.cpp
@@ -12,8 +12,8 @@ namespace Spire
 			{
 				RefPtr<ShaderComponentSymbol> ccomp;
 				RefPtr<ShaderClosure> su;
-				if ((comp.Value->Implementations.First()->SyntaxNode->IsPublic ||
-					comp.Value->Implementations.First()->SyntaxNode->IsOutput))
+				if ((comp.Value->Implementations.First()->SyntaxNode->IsPublic() ||
+					comp.Value->Implementations.First()->SyntaxNode->IsOutput()))
 				{
                     if (parent->Components.TryGetValue(comp.Key, ccomp))
                     {
@@ -123,7 +123,7 @@ namespace Spire
 							}
 						}
 						auto refClosure = CreateShaderClosure(err, symTable, shaderSym.Ptr(), import->Position, rootShader, refMap);
-						refClosure->IsPublic = import->IsPublic;
+						refClosure->IsPublic = import->IsPublic();
 						refClosure->Parent = rs.Ptr();
 						Token bindingVal;
 						if (import->Attributes.TryGetValue("Binding", bindingVal))
@@ -156,7 +156,7 @@ namespace Spire
 			// check for unassigned arguments
 			for (auto & comp : shader->Components)
 			{
-				if (comp.Value->Implementations.First()->SyntaxNode->IsRequire &&
+				if (comp.Value->Implementations.First()->SyntaxNode->IsRequire() &&
 					!pRefMap.ContainsKey(comp.Key))
 				{
                     err->diagnose(rs->UsingPosition, Diagnostics::parameterOfModuleIsUnassigned, comp.Key, shader->SyntaxNode->Name);
@@ -335,7 +335,7 @@ namespace Spire
 				{
 					if (auto comp = shaderClosure->FindComponent(var->Type->AsBasicType()->Component->Name))
 					{
-						if (comp->Implementations.First()->SyntaxNode->IsRequire)
+						if (comp->Implementations.First()->SyntaxNode->IsRequire())
 							shaderClosure->RefMap.TryGetValue(comp->Name, comp);
 						var->Tags["ComponentReference"] = new StringObject(comp->UniqueName);
 						AddReference(comp.Ptr(), currentImport, var->Position);
@@ -345,7 +345,7 @@ namespace Spire
 				}
 				if (auto comp = shaderClosure->FindComponent(var->Variable))
 				{
-					if (comp->Implementations.First()->SyntaxNode->IsRequire)
+					if (comp->Implementations.First()->SyntaxNode->IsRequire())
 						shaderClosure->RefMap.TryGetValue(var->Variable, comp);
 					var->Tags["ComponentReference"] = new StringObject(comp->UniqueName);
 
@@ -455,7 +455,7 @@ namespace Spire
 
 		bool IsInAbstractWorld(PipelineSymbol * pipeline, ShaderComponentSymbol* comp)
 		{
-			return comp->Implementations.First()->Worlds.Count() && !comp->Implementations.First()->SyntaxNode->IsRequire &&
+			return comp->Implementations.First()->Worlds.Count() && !comp->Implementations.First()->SyntaxNode->IsRequire() &&
 				pipeline->IsAbstractWorld(comp->Implementations.First()->Worlds.First());
 		}
 
@@ -470,7 +470,7 @@ namespace Spire
 				else
 				{
 					String uniqueChoiceName;
-					if (comp.Value->Implementations.First()->SyntaxNode->IsPublic)
+					if (comp.Value->Implementations.First()->SyntaxNode->IsPublic())
 						uniqueChoiceName = publicNamePrefix + comp.Key;
 					else
 						uniqueChoiceName = namePrefix + comp.Key;
@@ -546,7 +546,7 @@ namespace Spire
 		bool IsWorldFeasible(SymbolTable * symTable, PipelineSymbol * pipeline, ShaderComponentImplSymbol * impl, String world, ShaderComponentSymbol*& unaccessibleComp)
 		{
 			// shader parameter (uniform values) are available to all worlds
-			if (impl->SyntaxNode->IsParam)
+			if (impl->SyntaxNode->IsParam())
 				return true;
 			bool isWFeasible = true;
 			for (auto & dcomp : impl->DependentComponents)
@@ -770,7 +770,7 @@ namespace Spire
 
 				if (comp.Value.Symbol->Implementations.Count() == 1 &&
 					comp.Value.Symbol->Implementations.First()->SyntaxNode->Expression &&
-					!comp.Value.Symbol->Implementations.First()->SyntaxNode->IsOutput)
+					!comp.Value.Symbol->Implementations.First()->SyntaxNode->IsOutput())
 				{
 					RefPtr<Object> compRef;
 					if (comp.Value.Symbol->Implementations.First()->SyntaxNode->Expression->Tags.TryGetValue("ComponentReference", compRef))
@@ -869,7 +869,7 @@ namespace Spire
 							WorldSyntaxNode* worldDecl;
 							if (shader->Pipeline->Worlds.TryGetValue(world.World.Content, worldDecl))
 							{
-								if (worldDecl->IsAbstract)
+								if (worldDecl->IsAbstract())
 								{
 									inAbstractWorld = true;
 									if (userSpecifiedWorlds.Count() > 1)
@@ -881,7 +881,7 @@ namespace Spire
 							}
 						}
 					}
-					if (!inAbstractWorld && !impl->SyntaxNode->IsRequire && !impl->SyntaxNode->IsInput && !impl->SyntaxNode->IsParam
+					if (!inAbstractWorld && !impl->SyntaxNode->IsRequire() && !impl->SyntaxNode->IsInput() && !impl->SyntaxNode->IsParam()
 						&& !impl->SyntaxNode->Expression && !impl->SyntaxNode->BlockStatement)
 					{
 						err->diagnose(impl->SyntaxNode->Position, Diagnostics::nonAbstractComponentMustHaveImplementation);
@@ -895,7 +895,7 @@ namespace Spire
 							auto world = shader->Pipeline->Worlds.TryGetValue(w.World.Content);
 							if (world)
 							{
-								if ((*world)->IsAbstract)
+								if ((*world)->IsAbstract())
 									isDefinedInAbstractWorld = true;
 								else
 									isDefinedInNonAbstractWorld = true;

--- a/Source/SpireCore/Closure.cpp
+++ b/Source/SpireCore/Closure.cpp
@@ -126,7 +126,7 @@ namespace Spire
 						refClosure->IsPublic = import->IsPublic();
 						refClosure->Parent = rs.Ptr();
 						Token bindingVal;
-						if (import->Attributes.TryGetValue("Binding", bindingVal))
+						if (import->FindSimpleAttribute("Binding", bindingVal))
 						{
 							refClosure->BindingIndex = StringToInt(bindingVal.Content);
 						}
@@ -585,7 +585,7 @@ namespace Spire
 				comp->Type->FeasibleWorlds.Clear();
 				for (auto & impl : comp->Implementations)
 				{
-					auto & autoWorld = allWorlds;
+					auto autoWorld = allWorlds;
 					for (auto & w : impl->Worlds)
 					{
 						ShaderComponentSymbol* unaccessibleComp = nullptr;

--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -165,7 +165,7 @@ namespace Spire
 					else
 					{
 						Token bindingValStr;
-						if (module->SyntaxNode->Attributes.TryGetValue("Binding", bindingValStr))
+						if (module->SyntaxNode->FindSimpleAttribute("Binding", bindingValStr))
 						{
 							int bindingVal = StringToInt(bindingValStr.Content);
 							module->BindingIndex = bindingVal;
@@ -195,7 +195,7 @@ namespace Spire
 				{
 					bool hasParam = false;
 					for (auto & comp : module->SyntaxNode->GetMembersOfType<ComponentSyntaxNode>())
-						if (comp->IsParam)
+						if (comp->IsParam())
 						{
 							hasParam = true;
 							break;
@@ -213,7 +213,7 @@ namespace Spire
 				// first pass: add components to module layout definition, and assign them user-defined binding slots (if any).
 				for (auto def : shader->Definitions)
 				{
-					if (def->SyntaxNode->IsParam)
+					if (def->SyntaxNode->IsParam())
 					{
 						auto module = compiledShader->ModuleParamSets[def->ModuleInstance->BindingName]().Ptr();
 						RefPtr<ILModuleParameterInstance> param = new ILModuleParameterInstance();
@@ -250,7 +250,7 @@ namespace Spire
 							}
 
 							Token bindingValStr;
-							if (def->SyntaxNode->Attributes.TryGetValue("Binding", bindingValStr))
+							if (def->SyntaxNode->FindSimpleAttribute("Binding", bindingValStr))
 							{
 								int bindingVal = StringToInt(bindingValStr.Content);
 
@@ -276,7 +276,7 @@ namespace Spire
 				// second pass: assign binding slots for rest of resource components whose binding is not explicitly specified by user
 				for (auto def : shader->Definitions)
 				{
-					if (def->SyntaxNode->IsParam)
+					if (def->SyntaxNode->IsParam())
 					{
 						auto module = compiledShader->ModuleParamSets[def->ModuleInstance->BindingName]().Ptr();
 						auto & param = **module->Parameters.TryGetValue(def->UniqueName);
@@ -323,6 +323,26 @@ namespace Spire
 				}
 			}
 
+            ParameterQualifier GetParamQualifier(ParameterSyntaxNode* paramDecl)
+            {
+                if (paramDecl->modifiers.flags && ModifierFlag::InOut)
+                    return ParameterQualifier::InOut;
+                else if (paramDecl->modifiers.flags && ModifierFlag::Out)
+                    return ParameterQualifier::Out;
+                else
+                    return ParameterQualifier::In;
+            }
+
+            EnumerableDictionary<String, Token> CopyLayoutAttributes(Decl* decl)
+            {
+                EnumerableDictionary<String, Token> attrs;
+                for (auto attr : decl->GetLayoutAttributes())
+                {
+                    attrs[attr->Key] = attr->Value;
+                }
+                return attrs;
+            }
+
 			virtual void ProcessShader(ShaderIR * shader) override
 			{
 				currentShader = shader;
@@ -349,9 +369,9 @@ namespace Spire
 					genericTypeMappings[world.Key] = recordType;
 					w->Name = world.Key;
 					w->OutputType = recordType;
-					w->Attributes = world.Value->Attributes;
+					w->Attributes = CopyLayoutAttributes(world.Value);
 					w->Shader = compiledShader.Ptr();
-					w->IsAbstract = world.Value->IsAbstract;
+					w->IsAbstract = world.Value->IsAbstract();
 					auto impOps = pipeline->GetImportOperatorsFromSourceWorld(world.Key);
 					w->Position = world.Value->Position;
 					compiledShader->Worlds[world.Key] = w;
@@ -371,13 +391,13 @@ namespace Spire
 						if (compDef->World == world)
 							components.Add(compDef.Ptr());
 					// for abstract world, fill in record type now
-					if (world != "<uniform>" && pipeline->Worlds[world]()->IsAbstract)
+					if (world != "<uniform>" && pipeline->Worlds[world]()->IsAbstract())
 					{
 						auto compiledWorld = compiledShader->Worlds[world]();
 						for (auto & comp : components)
 						{
 							ILObjectDefinition compDef;
-							compDef.Attributes = comp->SyntaxNode->Attributes;
+							compDef.Attributes = CopyLayoutAttributes(comp->SyntaxNode.Ptr());
 							compDef.Name = comp->UniqueName;
 							compDef.Type = TranslateExpressionType(comp->Type.Ptr());
 							compDef.Position = comp->SyntaxNode->Position;
@@ -397,13 +417,13 @@ namespace Spire
 					auto &components = worldComps[world.Key]();
 					for (auto & comp : components)
 					{
-						if (comp->SyntaxNode->IsInput)
+						if (comp->SyntaxNode->IsInput())
 						{
 							ILObjectDefinition def;
 							def.Name = comp->UniqueName;
 							def.Type = TranslateExpressionType(comp->Type.Ptr());
 							def.Position = comp->SyntaxNode->Position;
-							def.Attributes = comp->SyntaxNode->Attributes;
+							def.Attributes = CopyLayoutAttributes(comp->SyntaxNode.Ptr());
 							world.Value->Inputs.Add(def);
 						}
 					}
@@ -419,18 +439,18 @@ namespace Spire
 						{
 							auto recType = genericTypeMappings[importExpr->ImportOperatorDef->SourceWorld.Content]().As<ILRecordType>();
 							ILObjectDefinition entryDef;
-							entryDef.Attributes = comp->SyntaxNode->Attributes;
+							entryDef.Attributes = CopyLayoutAttributes(comp->SyntaxNode.Ptr());
 							entryDef.Name = importExpr->ComponentUniqueName;
 							entryDef.Type = TranslateExpressionType(importExpr->Type.Ptr());
 							entryDef.Position = importExpr->Position;
 							recType->Members.AddIfNotExists(importExpr->ComponentUniqueName, entryDef);
 						});
 						// if comp is output, add comp to its world's record type
-						if (comp->SyntaxNode->IsOutput)
+						if (comp->SyntaxNode->IsOutput())
 						{
 							auto recType = genericTypeMappings[comp->World]().As<ILRecordType>();
 							ILObjectDefinition entryDef;
-							entryDef.Attributes = comp->SyntaxNode->Attributes;
+							entryDef.Attributes = CopyLayoutAttributes(comp->SyntaxNode.Ptr());
 							entryDef.Name = comp->UniqueName;
 							entryDef.Type = TranslateExpressionType(comp->Type.Ptr());
 							entryDef.Position = comp->SyntaxNode->Position;
@@ -492,7 +512,7 @@ namespace Spire
 						{
 							auto paramType = TranslateExpressionType(param->Type);
 							String paramName = EscapeDoubleUnderscore("p" + String(id) + "_" + param->Name.Content);
-							func->Parameters.Add(paramName, ILParameter(paramType, param->Qualifier));
+							func->Parameters.Add(paramName, ILParameter(paramType, GetParamQualifier(param.Ptr())));
 							auto argInstr = codeWriter.FetchArg(paramType, id + 1);
 							argInstr->Name = paramName;
 							variables.Add(param->Name.Content, argInstr);
@@ -523,7 +543,7 @@ namespace Spire
 				}
 				for (auto & world : pipeline->Worlds)
 				{
-					if (world.Value->IsAbstract)
+					if (world.Value->IsAbstract())
 						continue;
 					NamingCounter = 0;
 
@@ -585,14 +605,14 @@ namespace Spire
 				String varName = EscapeDoubleUnderscore(currentComponent->OriginalName);
 				RefPtr<ILType> type = TranslateExpressionType(currentComponent->Type);
 
-				if (comp->SyntaxNode->IsInput)
+				if (comp->SyntaxNode->IsInput())
 				{
 					auto loadInput = new LoadInputInstruction(type.Ptr(), comp->UniqueName);
 					codeWriter.Insert(loadInput);
 					variables.Add(currentComponent->UniqueName, loadInput);
 					return;
 				}
-				else if (comp->SyntaxNode->IsParam)
+				else if (comp->SyntaxNode->IsParam())
 				{
 					auto moduleInst = compiledShader->ModuleParamSets[comp->ModuleInstance->BindingName]();
 					auto param = moduleInst->Parameters[comp->UniqueName]().Ptr();
@@ -636,7 +656,7 @@ namespace Spire
 			}
 			virtual RefPtr<FunctionSyntaxNode> VisitFunction(FunctionSyntaxNode* function) override
 			{
-				if (function->IsExtern)
+				if (function->IsExtern())
 					return function;
 				RefPtr<ILFunction> func = new ILFunction();
 				result.Program->Functions.Add(function->InternalName, func);
@@ -647,7 +667,7 @@ namespace Spire
 				int id = 0;
 				for (auto &param : function->Parameters)
 				{
-					func->Parameters.Add(param->Name.Content, ILParameter(TranslateExpressionType(param->Type), param->Qualifier));
+					func->Parameters.Add(param->Name.Content, ILParameter(TranslateExpressionType(param->Type), GetParamQualifier(param.Ptr())));
 					auto op = FetchArg(param->Type.Ptr(), ++id);
 					op->Name = EscapeDoubleUnderscore(String("p_") + param->Name.Content);
 					variables.Add(param->Name.Content, op);
@@ -1154,10 +1174,10 @@ namespace Spire
 				{
 					if (basicType->Func)
 					{
-						funcName = basicType->Func->SyntaxNode->IsExtern ? basicType->Func->SyntaxNode->Name.Content : basicType->Func->SyntaxNode->InternalName;
+						funcName = basicType->Func->SyntaxNode->IsExtern() ? basicType->Func->SyntaxNode->Name.Content : basicType->Func->SyntaxNode->InternalName;
 						for (auto & param : basicType->Func->SyntaxNode->Parameters)
 						{
-							if (param->Qualifier == ParameterQualifier::Out || param->Qualifier == ParameterQualifier::InOut)
+							if (param->HasModifier(ModifierFlag::Out))
 							{
 								hasSideEffect = true;
 								break;
@@ -1171,7 +1191,7 @@ namespace Spire
 						funcName = GetComponentFunctionName(funcComp->SyntaxNode.Ptr());
 						for (auto & param : funcComp->SyntaxNode->Parameters)
 						{
-							if (param->Qualifier == ParameterQualifier::Out || param->Qualifier == ParameterQualifier::InOut)
+							if (param->HasModifier(ModifierFlag::Out))
 							{
 								hasSideEffect = true;
 								break;

--- a/Source/SpireCore/CompiledProgram.cpp
+++ b/Source/SpireCore/CompiledProgram.cpp
@@ -46,11 +46,7 @@ namespace Spire
 		}
 		ShaderChoiceValue ShaderChoiceValue::Parse(String str)
 		{
-			ShaderChoiceValue result;
-			int idx = str.IndexOf(':');
-			if (idx == -1)
-				return ShaderChoiceValue(str, "");
-			return ShaderChoiceValue(str.SubString(0, idx), str.SubString(idx + 1, str.Length() - idx - 1));
+			return ShaderChoiceValue(str);
 		}
 		
 }

--- a/Source/SpireCore/CompiledProgram.h
+++ b/Source/SpireCore/CompiledProgram.h
@@ -132,32 +132,28 @@ namespace Spire
 		class ShaderChoiceValue
 		{
 		public:
-			String WorldName, AlternateName;
+			String WorldName;
 			ShaderChoiceValue() = default;
-			ShaderChoiceValue(String world, String alt)
+			ShaderChoiceValue(String world)
 			{
 				WorldName = world;
-				AlternateName = alt;
 			}
 			static ShaderChoiceValue Parse(String str);
 			String ToString()
 			{
-				if (AlternateName.Length() == 0)
-					return WorldName;
-				else
-					return WorldName + ":" + AlternateName;
+				return WorldName;
 			}
 			bool operator == (const ShaderChoiceValue & val)
 			{
-				return WorldName == val.WorldName && AlternateName == val.AlternateName;
+				return WorldName == val.WorldName;
 			}
 			bool operator != (const ShaderChoiceValue & val)
 			{
-				return WorldName != val.WorldName || AlternateName != val.AlternateName;
+				return WorldName != val.WorldName;
 			}
 			int GetHashCode()
 			{
-				return WorldName.GetHashCode() ^ AlternateName.GetHashCode();
+				return WorldName.GetHashCode();
 			}
 		};
 

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -1149,35 +1149,19 @@ namespace Spire
 
         static RefPtr<Decl> ParseLocalVarDecls(Parser* parser)
         {
-            // TODO(tfoley): it is wasteful to allocate this if
-            // it won't always be needed/used
-            RefPtr<MultiDecl> multiDecl = new MultiDecl();
-		
-			parser->FillPosition(multiDecl.Ptr());
+			RefPtr<Variable> var = new Variable();
+			parser->FillPosition(var.Ptr());
 
-            multiDecl->modifiers = ParseModifiers(parser);
-			multiDecl->TypeNode = parser->ParseType();
-			while (!parser->tokenReader.IsAtEnd())
+            var->modifiers = ParseModifiers(parser);
+			var->TypeNode = parser->ParseType();
+			var->Name = parser->ReadToken(TokenType::Identifier);
+			if (AdvanceIf(parser, TokenType::OpAssign))
 			{
-				RefPtr<Variable> var = new Variable();
-				parser->FillPosition(var.Ptr());
-				Token name = parser->ReadToken(TokenType::Identifier);
-				var->Name = name;
-				if (parser->LookAheadToken(TokenType::OpAssign))
-				{
-					parser->ReadToken(TokenType::OpAssign);
-					var->Expr = parser->ParseExpression();
-				}
-
-				multiDecl->decls.Add(var);
-				if (parser->LookAheadToken(TokenType::Comma))
-					parser->ReadToken(TokenType::Comma);
-				else
-					break;
+				var->Expr = parser->ParseExpression();
 			}
 			parser->ReadToken(TokenType::Semicolon);
-			
-			return multiDecl;
+
+			return var;
         }
 
 		RefPtr<VarDeclrStatementSyntaxNode> Parser::ParseVarDeclrStatement()

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -811,10 +811,6 @@ namespace Spire
 			component->TypeNode = ParseType();
 			FillPosition(component.Ptr());
 			component->Name = ReadToken(TokenType::Identifier);
-			if (AdvanceIf(this, TokenType::Colon))
-			{
-				component->AlternateName = ReadToken(TokenType::Identifier);
-			}
 			if (AdvanceIf(this, TokenType::LParent))
 			{
 				while (!AdvanceIfMatch(this, TokenType::RParent))

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -111,7 +111,6 @@ namespace Spire
 			RefPtr<ShaderSyntaxNode>				ParseShader();
 			RefPtr<PipelineSyntaxNode>				ParsePipeline();
 			RefPtr<StageSyntaxNode>					ParseStage();
-			RefPtr<ComponentSyntaxNode>				ParseComponent();
 			RefPtr<WorldSyntaxNode>					ParseWorld();
 			RefPtr<RateSyntaxNode>					ParseRate();
 			RefPtr<ImportSyntaxNode>				ParseImport();
@@ -522,100 +521,6 @@ namespace Spire
             return typeDefDecl;
         }
 
-		RefPtr<ProgramSyntaxNode> Parser::ParseProgram()
-		{
-			scopeStack.Add(new Scope());
-			RefPtr<ProgramSyntaxNode> program = new ProgramSyntaxNode();
-			program->Position = CodePosition(0, 0, 0, fileName);
-			program->Scope = scopeStack.Last();
-			while (!tokenReader.IsAtEnd())
-			{
-				EnumerableDictionary<String, Token> attributes;
-				while (AdvanceIf(this, TokenType::LBracket))
-				{
-					attributes[ReadToken(TokenType::Identifier).Content] = ReadToken();
-					ReadToken(TokenType::RBracket);
-				}
-				if (LookAheadToken("shader") || LookAheadToken("module"))
-				{
-					auto shader = ParseShader();
-					shader->Attributes = _Move(attributes);
-					program->Members.Add(shader);
-				}
-				else if (LookAheadToken("pipeline"))
-					program->Members.Add(ParsePipeline());
-				else if (LookAheadToken("struct"))
-					program->Members.Add(ParseStruct());
-				else if (LookAheadToken("typedef"))
-					program->Members.Add(ParseTypeDef(this));
-				else if (LookAheadToken("using"))
-				{
-					ReadToken("using");
-					program->Usings.Add(ReadToken(TokenType::StringLiterial));
-					ReadToken(TokenType::Semicolon);
-				}
-				else if (IsTypeKeyword() || LookAheadToken("inline") || LookAheadToken("extern")
-					|| LookAheadToken("__intrinsic") || LookAheadToken(TokenType::Identifier))
-					program->Members.Add(ParseFunction());
-                else if (AdvanceIf(this, TokenType::Semicolon))
-                {}
-				else
-				{
-                    Unexpected(this);
-                    TryRecover(this);
-				}
-			}
-			scopeStack.Clear();
-			return program;
-		}
-
-		RefPtr<ShaderSyntaxNode> Parser::ParseShader()
-		{
-			RefPtr<ShaderSyntaxNode> shader = new ShaderSyntaxNode();
-			if (AdvanceIf(this, "module"))
-			{
-				shader->IsModule = true;
-			}
-			else
-				ReadToken("shader");
-			PushScope();
-			FillPosition(shader.Ptr());
-			shader->Name = ReadToken(TokenType::Identifier);
-			if (AdvanceIf(this, TokenType::Colon))
-			{
-				shader->ParentPipelineName = ReadToken(TokenType::Identifier);
-			}
-			
-			ReadToken(TokenType::LBrace);
-			while (!AdvanceIfMatch(this, TokenType::RBrace))
-			{
-				auto attribs = ParseAttribute();
-				if (LookAheadToken("inline") || (LookAheadToken("public") && !LookAheadToken("using", 1)) ||
-					LookAheadToken("out") || LookAheadToken(TokenType::At) || IsTypeKeyword() ||
-					LookAheadToken("require") || LookAheadToken("extern") || LookAheadToken("param"))
-				{
-					auto comp = ParseComponent();
-					comp->ParentDecl = shader.Ptr();
-					comp->Attributes = attribs;
-					shader->Members.Add(comp);
-				}
-				else if (LookAheadToken("using") || (LookAheadToken("public") && LookAheadToken("using", 1)))
-				{
-					auto imp = ParseImport();
-					imp->ParentDecl = shader.Ptr();
-					imp->Attributes = attribs;
-					shader->Members.Add(imp);
-				}
-				else
-				{
-                    Unexpected(this);
-                    TryRecover(this);
-				}
-			}
-			PopScope();
-			return shader;
-		}
-
         static Modifiers ParseModifiers(Parser* parser)
         {
             Modifiers modifiers;
@@ -705,16 +610,16 @@ namespace Spire
                 else if (AdvanceIf(parser, TokenType::LBracket))
                 {
                     auto name = parser->ReadToken(TokenType::Identifier).Content;
-                    String value;
+                    Token valueToken;
                     if (AdvanceIf(parser, TokenType::Colon))
                     {
-                        value = parser->ReadToken(TokenType::StringLiterial).Content;
+                        valueToken = parser->ReadToken(TokenType::StringLiterial);
                     }
                     parser->ReadToken(TokenType::RBracket);
 
                     RefPtr<SimpleAttribute> modifier = new SimpleAttribute();
                     modifier->Key = name;
-                    modifier->Value = value;
+                    modifier->Value = valueToken;
 
                     *modifierLink = modifier;
                     modifierLink = &modifier->next;
@@ -731,6 +636,353 @@ namespace Spire
             }
         }
 
+        static RefPtr<Decl> ParseUsing(
+            Parser* parser)
+        {
+            parser->ReadToken("using");
+            if (parser->tokenReader.PeekTokenType() == TokenType::StringLiterial)
+            {
+                auto usingDecl = new UsingFileDecl();
+                usingDecl->fileName = parser->ReadToken(TokenType::StringLiterial);
+                parser->ReadToken(TokenType::Semicolon);
+                return usingDecl;
+            }
+            else
+            {
+                // This is an import decl
+                return parser->ParseImport();
+            }
+        }
+
+        static Token ParseDeclName(
+            Parser* parser)
+        {
+            Token name;
+            if (AdvanceIf(parser, "operator"))
+			{
+				name = parser->ReadToken();
+				switch (name.Type)
+				{
+				case TokenType::OpAdd: case TokenType::OpSub: case TokenType::OpMul: case TokenType::OpDiv:
+				case TokenType::OpMod: case TokenType::OpNot: case TokenType::OpBitNot: case TokenType::OpLsh: case TokenType::OpRsh:
+				case TokenType::OpEql: case TokenType::OpNeq: case TokenType::OpGreater: case TokenType::OpLess: case TokenType::OpGeq:
+				case TokenType::OpLeq: case TokenType::OpAnd: case TokenType::OpOr: case TokenType::OpBitXor: case TokenType::OpBitAnd:
+				case TokenType::OpBitOr: case TokenType::OpInc: case TokenType::OpDec:
+					break;
+				default:
+					parser->sink->diagnose(name.Position, Diagnostics::invalidOperator, name.Content);
+					break;
+				}
+			}
+			else
+			{
+				name = parser->ReadToken(TokenType::Identifier);
+			}
+            return name;
+        }
+
+        struct DeclaratorInfo
+        {
+            RefPtr<RateSyntaxNode>  rate;
+            RefPtr<TypeSyntaxNode>  typeSpec;
+            Token                   nameToken;
+        };
+
+        static void ParseFuncDeclHeader(
+            Parser*                     parser,
+            DeclaratorInfo const&       declaratorInfo,
+            RefPtr<FunctionSyntaxNode>  decl)
+        {
+            parser->anonymousParamCounter = 0;
+            parser->FillPosition(decl.Ptr());
+            decl->Position = declaratorInfo.nameToken.Position;
+
+            parser->PushScope();
+            decl->Name = declaratorInfo.nameToken;
+            decl->ReturnTypeNode = declaratorInfo.typeSpec;
+            parser->ReadToken(TokenType::LParent);
+            while (!AdvanceIfMatch(parser, TokenType::RParent))
+            {
+                decl->Parameters.Add(parser->ParseParameter());
+                if (AdvanceIf(parser, TokenType::RParent))
+                    break;
+                parser->ReadToken(TokenType::Comma);
+            }
+        }
+
+        static void ParseFuncDeclHeader(
+            Parser*                     parser,
+            DeclaratorInfo const&       declaratorInfo,
+            RefPtr<ComponentSyntaxNode> decl)
+        {
+            parser->anonymousParamCounter = 0;
+            parser->FillPosition(decl.Ptr());
+            decl->Position = declaratorInfo.nameToken.Position;
+
+            parser->PushScope();
+            decl->Name = declaratorInfo.nameToken;
+            decl->TypeNode = declaratorInfo.typeSpec;
+            parser->ReadToken(TokenType::LParent);
+            while (!AdvanceIfMatch(parser, TokenType::RParent))
+            {
+                decl->Parameters.Add(parser->ParseParameter());
+                if (AdvanceIf(parser, TokenType::RParent))
+                    break;
+                parser->ReadToken(TokenType::Comma);
+            }
+        }
+
+        static RefPtr<Decl> ParseFuncDecl(
+            Parser*                 parser,
+            ContainerDecl*          containerDecl,
+            DeclaratorInfo const&   declaratorInfo)
+        {
+            if (dynamic_cast<ShaderDeclBase*>(containerDecl))
+            {
+                // inside a shader, we create a component decl
+                RefPtr<ComponentSyntaxNode> decl = new ComponentSyntaxNode();
+                ParseFuncDeclHeader(parser, declaratorInfo, decl);
+
+                //
+                decl->Rate = declaratorInfo.rate;
+                //
+
+                if (AdvanceIf(parser, TokenType::Semicolon))
+                {
+                    // empty body
+                }
+                else
+                {
+                    decl->BlockStatement = parser->ParseBlockStatement();
+                }
+
+                parser->PopScope();
+                return decl;
+            }
+            else
+            {
+                // everywhere else, we create an ordinary `FunctionSyntaxNode`
+
+                RefPtr<FunctionSyntaxNode> decl = new FunctionSyntaxNode();
+                ParseFuncDeclHeader(parser, declaratorInfo, decl);
+
+                if (AdvanceIf(parser, TokenType::Semicolon))
+                {
+                    // empty body
+                }
+                else
+                {
+                    decl->Body = parser->ParseBlockStatement();
+                }
+
+                parser->PopScope();
+                return decl;
+            }
+        }
+
+        static RefPtr<VarDeclBase> CreateVarDeclForContext(
+            ContainerDecl*  containerDecl )
+        {
+            if (dynamic_cast<StructSyntaxNode*>(containerDecl))
+            {
+                return new StructField();
+            }
+            else if (dynamic_cast<FunctionDeclBase*>(containerDecl))
+            {
+                return new ParameterSyntaxNode();
+            }
+            else
+            {
+                return new Variable();
+            }
+        }
+
+        static RefPtr<Decl> ParseVarDecl(
+            Parser*                 parser,
+            ContainerDecl*          containerDecl,
+            DeclaratorInfo const&   declaratorInfo)
+        {
+            if (dynamic_cast<ShaderDeclBase*>(containerDecl))
+            {
+                // inside a shader, we create a component decl
+                RefPtr<ComponentSyntaxNode> decl = new ComponentSyntaxNode();
+                parser->FillPosition(decl.Ptr());
+                decl->Position = declaratorInfo.nameToken.Position;
+
+                //
+                decl->Rate = declaratorInfo.rate;
+                //
+
+                decl->Name = declaratorInfo.nameToken;
+                decl->TypeNode = declaratorInfo.typeSpec;
+
+                // Note(tfoley): this case is the one place where a component
+                // declaration differents in any meaningful way from an
+                // ordinary variable declaration.
+                if (parser->tokenReader.PeekTokenType() == TokenType::LBrace)
+                {
+                    decl->BlockStatement = parser->ParseBlockStatement();
+                }
+                else
+                {
+                    if (AdvanceIf(parser, TokenType::OpAssign))
+                    {
+                        decl->Expression = parser->ParseExpression();
+                    }
+                    // TODO(tfoley): support the block case here
+                    parser->ReadToken(TokenType::Semicolon);
+                }
+
+                return decl;
+            }
+            else
+            {
+                // everywhere else, we create an ordinary `VarDeclBase`
+                RefPtr<VarDeclBase> decl = CreateVarDeclForContext(containerDecl);
+                parser->FillPosition(decl.Ptr());
+                decl->Position = declaratorInfo.nameToken.Position;
+
+                decl->Name = declaratorInfo.nameToken;
+                decl->TypeNode = declaratorInfo.typeSpec;
+
+                if (AdvanceIf(parser, TokenType::OpAssign))
+                {
+                    decl->Expr = parser->ParseExpression();
+                }
+                parser->ReadToken(TokenType::Semicolon);
+
+                return decl;
+            }
+        }
+
+        static RefPtr<Decl> ParseDeclaratorDecl(
+            Parser*         parser,
+            ContainerDecl*  containerDecl)
+        {
+            DeclaratorInfo declaratorInfo;
+
+            // For now we just parse <type-spec> <decl-name>
+            //
+            // TODO(tfoley): Actual C-style declarator-based parsed.
+            //
+            if (parser->tokenReader.PeekTokenType() == TokenType::At)
+            {
+                declaratorInfo.rate = parser->ParseRate();
+            }
+            declaratorInfo.typeSpec = parser->ParseType();
+            declaratorInfo.nameToken = ParseDeclName(parser);
+
+            // TODO(tfoley): handle array-ness here...
+
+            // Look at the token after the name to disambiguate
+            switch (parser->tokenReader.PeekTokenType())
+            {
+            case TokenType::LParent:
+                // It must be a function
+                return ParseFuncDecl(parser, containerDecl, declaratorInfo);
+
+            default:
+                // Assume it is a variable-like declaration
+                return ParseVarDecl(parser, containerDecl, declaratorInfo);
+            }
+        }
+
+        static RefPtr<Decl> ParseDeclWithModifiers(
+            Parser*             parser,
+            ContainerDecl*      containerDecl,
+            Modifiers const&    modifiers )
+        {
+            RefPtr<Decl> decl;
+
+            // TODO: actual dispatch!
+            if (parser->LookAheadToken("shader") || parser->LookAheadToken("module"))
+                decl = parser->ParseShader();
+            else if (parser->LookAheadToken("pipeline"))
+                decl = parser->ParsePipeline();
+            else if (parser->LookAheadToken("struct"))
+                decl = parser->ParseStruct();
+            else if (parser->LookAheadToken("typedef"))
+                decl = ParseTypeDef(parser);
+            else if (parser->LookAheadToken("using"))
+                decl = ParseUsing(parser);
+            else if (parser->LookAheadToken("world"))
+                decl = parser->ParseWorld();
+            else if (parser->LookAheadToken("import"))
+                decl = parser->ParseImportOperator();
+            else if (parser->LookAheadToken("stage"))
+                decl = parser->ParseStage();
+            else if (AdvanceIf(parser, TokenType::Semicolon))
+            {
+                // empty declaration
+            }
+            else
+                decl = ParseDeclaratorDecl(parser, containerDecl);
+
+            if (decl)
+            {
+                decl->modifiers = modifiers;
+            }
+            return decl;
+        }
+
+        static RefPtr<Decl> ParseDecl(
+            Parser*         parser,
+            ContainerDecl*  containerDecl)
+        {
+            Modifiers modifiers = ParseModifiers(parser);
+            return ParseDeclWithModifiers(parser, containerDecl, modifiers);
+        }
+
+        // Parse a body consisting of declarations
+        static void ParseDeclBody(
+            Parser*         parser,
+            ContainerDecl*  containerDecl,
+            CoreLib::Text::TokenType       closingToken)
+        {
+            while(!AdvanceIfMatch(parser, closingToken))
+            {
+                RefPtr<Decl> decl = ParseDecl(parser, containerDecl);
+                if (decl)
+                {
+                    containerDecl->Members.Add(decl);
+                }
+                TryRecover(parser);
+            }
+        }
+
+		RefPtr<ProgramSyntaxNode> Parser::ParseProgram()
+		{
+			scopeStack.Add(new Scope());
+			RefPtr<ProgramSyntaxNode> program = new ProgramSyntaxNode();
+			program->Position = CodePosition(0, 0, 0, fileName);
+			program->Scope = scopeStack.Last();
+            ParseDeclBody(this, program.Ptr(), TokenType::EndOfFile);
+			scopeStack.Clear();
+			return program;
+		}
+
+		RefPtr<ShaderSyntaxNode> Parser::ParseShader()
+		{
+			RefPtr<ShaderSyntaxNode> shader = new ShaderSyntaxNode();
+			if (AdvanceIf(this, "module"))
+			{
+				shader->IsModule = true;
+			}
+			else
+				ReadToken("shader");
+			PushScope();
+			FillPosition(shader.Ptr());
+			shader->Name = ReadToken(TokenType::Identifier);
+			if (AdvanceIf(this, TokenType::Colon))
+			{
+				shader->ParentPipelineName = ReadToken(TokenType::Identifier);
+			}
+			
+			ReadToken(TokenType::LBrace);
+            ParseDeclBody(this, shader.Ptr(), TokenType::RBrace);
+			PopScope();
+			return shader;
+		}
 
 		RefPtr<PipelineSyntaxNode> Parser::ParsePipeline()
 		{
@@ -744,35 +996,7 @@ namespace Spire
 				pipeline->ParentPipelineName = ReadToken(TokenType::Identifier);
 			}
 			ReadToken(TokenType::LBrace);
-			while (!AdvanceIfMatch(this, TokenType::RBrace))
-			{
-                auto modifiers = ParseModifiers(this);
-				if (LookAheadToken("input") || LookAheadToken("world"))
-				{
-					auto w = ParseWorld();
-					w->modifiers = modifiers;
-					pipeline->Members.Add(w);
-				}
-				else if (LookAheadToken("import"))
-				{
-					auto op = ParseImportOperator();
-					op->modifiers = modifiers;
-					pipeline->Members.Add(op);
-				}
-				else if (LookAheadToken("stage"))
-				{
-					pipeline->Members.Add(ParseStage());
-					isStage = true;
-				}
-				else
-				{
-					auto comp = ParseComponent();
-					comp->modifiers = modifiers;
-					pipeline->Members.Add(comp);
-				}
-				if (!isStage) // stage's attributes are part of stage syntax
-					pipeline->Members.Last()->Attributes = attribs;
-			}
+            ParseDeclBody(this, pipeline.Ptr(), TokenType::RBrace);
 			PopScope();
 			return pipeline;
 		}
@@ -799,41 +1023,6 @@ namespace Spire
 				ReadToken(TokenType::Semicolon);
 			}
 			return stage;
-		}
-
-		RefPtr<ComponentSyntaxNode> Parser::ParseComponent()
-		{
-			RefPtr<ComponentSyntaxNode> component = new ComponentSyntaxNode();
-			PushScope();
-            component->modifiers = ParseModifiers(this);
-			if (LookAheadToken(TokenType::At))
-				component->Rate = ParseRate();
-			component->TypeNode = ParseType();
-			FillPosition(component.Ptr());
-			component->Name = ReadToken(TokenType::Identifier);
-			if (AdvanceIf(this, TokenType::LParent))
-			{
-				while (!AdvanceIfMatch(this, TokenType::RParent))
-				{
-					component->Parameters.Add(ParseParameter());
-                    if (AdvanceIf(this, TokenType::RParent))
-                        break;
-                    ReadToken(TokenType::Comma);
-				}
-			}
-			if (AdvanceIf(this, TokenType::OpAssign))
-			{
-				component->Expression = ParseExpression();
-				ReadToken(TokenType::Semicolon);
-			}
-			else if (LookAheadToken(TokenType::LBrace))
-			{
-				component->BlockStatement = ParseBlockStatement();
-			}
-			else
-				ReadToken(TokenType::Semicolon);
-			PopScope();
-			return component;
 		}
 
 		RefPtr<WorldSyntaxNode> Parser::ParseWorld()
@@ -1039,24 +1228,9 @@ namespace Spire
 				ReadToken();
 				rs->IsIntrinsic = true;
 			}
-			ReadToken(TokenType::LBrace);
-			while (!AdvanceIfMatch(this, TokenType::RBrace))
-			{
-				RefPtr<TypeSyntaxNode> type = ParseType();
-				do
-				{
-					RefPtr<StructField> field = new StructField();
-					FillPosition(field.Ptr());
-					field->TypeNode = type;
-					field->Name = ReadToken(TokenType::Identifier);
-					rs->Members.Add(field);
-					if (!LookAheadToken(TokenType::Comma))
-						break;
-					ReadToken(TokenType::Comma);
-				} while (!tokenReader.IsAtEnd());
-				ReadToken(TokenType::Semicolon);
-			}
 			typeNames.Add(rs->Name.Content);
+			ReadToken(TokenType::LBrace);
+            ParseDeclBody(this, rs.Ptr(), TokenType::RBrace);
 			return rs;
 		}
 
@@ -1143,29 +1317,12 @@ namespace Spire
 			return blockStatement;
 		}
 
-        static RefPtr<Decl> ParseLocalVarDecls(Parser* parser)
-        {
-			RefPtr<Variable> var = new Variable();
-			parser->FillPosition(var.Ptr());
-
-            var->modifiers = ParseModifiers(parser);
-			var->TypeNode = parser->ParseType();
-			var->Name = parser->ReadToken(TokenType::Identifier);
-			if (AdvanceIf(parser, TokenType::OpAssign))
-			{
-				var->Expr = parser->ParseExpression();
-			}
-			parser->ReadToken(TokenType::Semicolon);
-
-			return var;
-        }
-
 		RefPtr<VarDeclrStatementSyntaxNode> Parser::ParseVarDeclrStatement()
 		{
 			RefPtr<VarDeclrStatementSyntaxNode>varDeclrStatement = new VarDeclrStatementSyntaxNode();
 		
 			FillPosition(varDeclrStatement.Ptr());
-            varDeclrStatement->decl = ParseLocalVarDecls(this);
+            varDeclrStatement->decl = ParseDecl(this, nullptr);
 			return varDeclrStatement;
 		}
 

--- a/Source/SpireCore/Schedule.cpp
+++ b/Source/SpireCore/Schedule.cpp
@@ -120,16 +120,7 @@ namespace Spire
 								auto token = ReadToken(TokenType::StringLiterial);
 								RefPtr<ChoiceValueSyntaxNode> choiceValue = new ChoiceValueSyntaxNode();
 								choiceValue->Position = token.Position;
-								int splitterPos = token.Content.IndexOf(':');
-								if (splitterPos != -1)
-								{
-									choiceValue->WorldName = token.Content.SubString(0, splitterPos);
-									choiceValue->AlternateName = token.Content.SubString(splitterPos + 1, token.Content.Length() - splitterPos - 1);
-								}
-								else
-								{
-									choiceValue->WorldName = token.Content;
-								}
+								choiceValue->WorldName = token.Content;
 								worlds.Add(choiceValue);
 								if (LookAheadToken(","))
 									ReadToken(TokenType::Comma);

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -277,7 +277,7 @@ namespace Spire
 				for (auto comp : pipeline->GetAbstractComponents())
 				{
 					comp->Type = TranslateTypeNode(comp->TypeNode);
-					if (comp->IsRequire || comp->IsInput || (comp->Rate && comp->Rate->Worlds.Count() == 1
+					if (comp->IsRequire() || comp->IsInput() || (comp->Rate && comp->Rate->Worlds.Count() == 1
 						&& psymbol->IsAbstractWorld(comp->Rate->Worlds.First().World.Content)))
 						AddNewComponentSymbol(psymbol->Components, psymbol->FunctionComponents, comp);
                     else
@@ -296,7 +296,7 @@ namespace Spire
 						getSink()->diagnose(op->DestWorld, Diagnostics::undefinedWorldName, op->DestWorld.Content);
 					else
 					{
-						if (psymbol->Worlds[op->DestWorld.Content].GetValue()->IsAbstract)
+						if (psymbol->Worlds[op->DestWorld.Content].GetValue()->IsAbstract())
 							getSink()->diagnose(op->DestWorld, Diagnostics::abstractWorldAsTargetOfImport);
 						else if (!psymbol->WorldDependency.ContainsKey(op->SourceWorld.Content))
 							getSink()->diagnose(op->SourceWorld, Diagnostics::undefinedWorldName2, op->SourceWorld.Content);
@@ -481,19 +481,15 @@ namespace Spire
 					currentShader->Components.TryGetValue(comp->Name.Content, compSym);
 					currentComp = compSym.Ptr();
 					SyntaxVisitor::VisitComponent(comp);
-					if (comp->Parameters.Count() > 0)
-					{
-						comp->IsInline = true;
-					}
 					if (comp->Expression || comp->BlockStatement)
 					{
 						if (compSym->IsRequire())
 							getSink()->diagnose(comp, Diagnostics::requireWithComputation);
-						if (comp->IsParam)
+						if (comp->IsParam())
 							getSink()->diagnose(comp, Diagnostics::paramWithComputation);
 					}
-					if (compSym->Type->DataType->GetBindableResourceType() != BindableResourceType::NonBindable && !comp->IsParam
-						&& !comp->IsRequire)
+					if (compSym->Type->DataType->GetBindableResourceType() != BindableResourceType::NonBindable && !comp->IsParam()
+						&& !comp->IsRequire())
 						getSink()->diagnose(comp, Diagnostics::resourceTypeMustBeParamOrRequire, comp->Name);
 					currentComp = nullptr;
 					return comp;
@@ -509,7 +505,7 @@ namespace Spire
 					{
 						ShaderUsing su;
 						su.Shader = refShader.Ptr();
-						su.IsPublic = import->IsPublic;
+						su.IsPublic = import->IsPublic();
 						if (import->IsInplace)
 						{
 							currentShader->ShaderUsings.Add(su);
@@ -575,7 +571,7 @@ namespace Spire
 					if (auto comp = dynamic_cast<ComponentSyntaxNode*>(mbr.Ptr()))
 					{
 						comp->Type = TranslateTypeNode(comp->TypeNode);
-						if (comp->IsRequire)
+						if (comp->IsRequire())
 						{
 							shaderSymbol->IsAbstract = true;
 							if (!shaderSymbol->SyntaxNode->IsModule)
@@ -725,7 +721,7 @@ namespace Spire
 				{
 					compImpl->AlternateName = compImpl->SyntaxNode->AlternateName.Content;
 				}
-				if (compImpl->SyntaxNode->IsOutput)
+				if (compImpl->SyntaxNode->IsOutput())
 				{
 					if (compImpl->SyntaxNode->Rate)
 					{
@@ -750,7 +746,7 @@ namespace Spire
 				}
 				else
 				{
-					if (comp->IsRequire)
+					if (comp->IsRequire())
 						getSink()->diagnose(compImpl->SyntaxNode.Ptr(), Diagnostics::requirementsClashWithPreviousDef, compImpl->SyntaxNode->Name.Content);
 					else
 					{
@@ -878,7 +874,7 @@ namespace Spire
 
 			virtual RefPtr<FunctionSyntaxNode> VisitFunction(FunctionSyntaxNode *functionNode) override
 			{
-				if (!functionNode->IsExtern)
+				if (!functionNode->IsExtern())
 				{
 					currentFunc = symbolTable->Functions.TryGetValue(functionNode->InternalName)->Ptr();
 					this->function = functionNode;
@@ -1462,7 +1458,7 @@ namespace Spire
 				}
 				if (func)
 				{
-					if (!func->SyntaxNode->IsExtern)
+					if (!func->SyntaxNode->IsExtern())
 					{
 						varExpr->Variable = func->SyntaxNode->InternalName;
 						if (currentFunc)
@@ -1552,8 +1548,7 @@ namespace Spire
 						{
 							for (int i = 0; i < (*params).Count(); i++)
 							{
-								if ((*params)[i]->Qualifier == ParameterQualifier::Out ||
-									(*params)[i]->Qualifier == ParameterQualifier::InOut)
+								if ((*params)[i]->HasModifier(ModifierFlag::Out))
 								{
 									if (i < expr->Arguments.Count() && expr->Arguments[i]->Type->AsBasicType() &&
 										!expr->Arguments[i]->Type->AsBasicType()->IsLeftValue)

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -717,10 +717,6 @@ namespace Spire
 						if (w.Pinned)
 							compImpl->SrcPinnedWorlds.Add(w.World.Content);
 				}
-				if (compImpl->SyntaxNode->AlternateName.Type == TokenType::Identifier)
-				{
-					compImpl->AlternateName = compImpl->SyntaxNode->AlternateName.Content;
-				}
 				if (compImpl->SyntaxNode->IsOutput())
 				{
 					if (compImpl->SyntaxNode->Rate)

--- a/Source/SpireCore/ShaderCompiler.cpp
+++ b/Source/SpireCore/ShaderCompiler.cpp
@@ -45,9 +45,9 @@ namespace Spire
 							{
 								try
 								{
-									if (attrib->Value.StartsWith("%"))
+									if (attrib->GetValue().StartsWith("%"))
 									{
-										CoreLib::Text::TokenReader parser(attrib->Value.SubString(1, attrib->Value.Length() - 1));
+										CoreLib::Text::TokenReader parser(attrib->GetValue().SubString(1, attrib->GetValue().Length() - 1));
 										auto compName = parser.ReadWord();
 										parser.Read(".");
 										auto compAttrib = parser.ReadWord();
@@ -142,7 +142,7 @@ namespace Spire
                             {
                                 auto modifier = new SimpleAttribute();
                                 modifier->Key = attrib.Key;
-                                modifier->Value = attrib.Value;
+                                modifier->Value.Content = attrib.Value;
 
                                 modifier->next = impl->SyntaxNode->modifiers.first;
                                 impl->SyntaxNode->modifiers.first = modifier;

--- a/Source/SpireCore/ShaderCompiler.cpp
+++ b/Source/SpireCore/ShaderCompiler.cpp
@@ -119,7 +119,7 @@ namespace Spire
 								// find specified impl
 								for (auto & impl : comp->Implementations)
 								{
-									if (impl->AlternateName == selectedDef->AlternateName && impl->Worlds.Contains(selectedDef->WorldName))
+									if (impl->Worlds.Contains(selectedDef->WorldName))
 										pinnedImpl.Add(impl.Ptr());
 								}
 							}
@@ -434,7 +434,7 @@ namespace Spire
 									{
 										for (auto w : impl->Worlds)
 											if (comp.Value.Symbol->Type->ConstrainedWorlds.Contains(w))
-												choice.Options.Add(ShaderChoiceValue(w, impl->AlternateName));
+												choice.Options.Add(ShaderChoiceValue(w));
 									}
 									if (auto defs = shader.Value->IR->DefinitionsByComponent.TryGetValue(comp.Key))
 									{

--- a/Source/SpireCore/ShaderCompiler.cpp
+++ b/Source/SpireCore/ShaderCompiler.cpp
@@ -41,13 +41,13 @@ namespace Spire
 					for (auto & comp : comps)
 					{
 						for (auto & impl : comp->Implementations)
-							for (auto & attrib : impl->SyntaxNode->Attributes)
+							for (auto attrib : impl->SyntaxNode->GetLayoutAttributes())
 							{
 								try
 								{
-									if (attrib.Value.Content.StartsWith("%"))
+									if (attrib->Value.StartsWith("%"))
 									{
-										CoreLib::Text::TokenReader parser(attrib.Value.Content.SubString(1, attrib.Value.Content.Length() - 1));
+										CoreLib::Text::TokenReader parser(attrib->Value.SubString(1, attrib->Value.Length() - 1));
 										auto compName = parser.ReadWord();
 										parser.Read(".");
 										auto compAttrib = parser.ReadWord();
@@ -57,8 +57,8 @@ namespace Spire
 											for (auto & timpl : compSym->Implementations)
 											{
 												Token attribValue;
-												if (timpl->SyntaxNode->Attributes.TryGetValue(compAttrib, attribValue))
-													attrib.Value = attribValue;
+												if (timpl->SyntaxNode->FindSimpleAttribute(compAttrib, attribValue))
+													attrib->Value = attribValue;
 											}
 										}
 									}
@@ -90,7 +90,7 @@ namespace Spire
 					{
 						for (auto & w : impl->Worlds)
 						{
-							if (impl->SrcPinnedWorlds.Contains(w) || impl->SyntaxNode->IsInline || impl->ExportWorlds.Contains(w) || impl->SyntaxNode->IsInput)
+							if (impl->SrcPinnedWorlds.Contains(w) || impl->SyntaxNode->IsInline() || impl->ExportWorlds.Contains(w) || impl->SyntaxNode->IsInput())
 							{
 								comp.Value->Type->PinnedWorlds.Add(w);
 							}
@@ -127,6 +127,26 @@ namespace Spire
 							{
                                 cresult.GetErrorWriter()->diagnose(selectedDef.Ptr()->Position, Diagnostics::worldIsNotAValidChoiceForKey, selectedDef->WorldName, choice.Key);
 							}
+						}
+					}
+				}
+				for (auto & attribs : schedule.AddtionalAttributes)
+				{
+					ShaderComponentSymbol * comp = nullptr;
+					if (choiceComps.TryGetValue(attribs.Key, comp))
+					{
+						// apply attributes
+						for (auto & impl : comp->Implementations)
+						{
+                            for (auto & attrib : attribs.Value)
+                            {
+                                auto modifier = new SimpleAttribute();
+                                modifier->Key = attrib.Key;
+                                modifier->Value = attrib.Value;
+
+                                modifier->next = impl->SyntaxNode->modifiers.first;
+                                impl->SyntaxNode->modifiers.first = modifier;
+                            }
 						}
 					}
 				}
@@ -180,9 +200,9 @@ namespace Spire
 							def->UniqueKey = comp.Value.Symbol->UniqueKey;
 							def->UniqueName = comp.Value.Symbol->UniqueName;
 							def->Type = comp.Value.Symbol->Type->DataType;
-							def->IsEntryPoint = (impl->ExportWorlds.Contains(w) || impl->SyntaxNode->IsParam ||
+							def->IsEntryPoint = (impl->ExportWorlds.Contains(w) || impl->SyntaxNode->IsParam() ||
 								(shader->Pipeline->IsAbstractWorld(w) &&
-								(impl->SyntaxNode->Attributes.ContainsKey("Pinned") || shader->Pipeline->Worlds[w]()->Attributes.ContainsKey("Pinned"))));
+								(impl->SyntaxNode->HasSimpleAttribute("Pinned") || shader->Pipeline->Worlds[w]()->HasSimpleAttribute("Pinned"))));
 							CloneContext cloneCtx;
 							def->SyntaxNode = impl->SyntaxNode->Clone(cloneCtx);
 							def->World = w;
@@ -190,7 +210,7 @@ namespace Spire
 							return def;
 						};
 						// parameter component will only have one defintion that is shared by all worlds
-						if (impl->SyntaxNode->IsParam)
+						if (impl->SyntaxNode->IsParam())
 						{
 							auto def = createComponentDef("<uniform>");
 							result->Definitions.Add(def);

--- a/Source/SpireCore/SymbolTable.cpp
+++ b/Source/SpireCore/SymbolTable.cpp
@@ -142,7 +142,7 @@ namespace Spire
 		{
 			WorldSyntaxNode* worldDecl;
 			if (Worlds.TryGetValue(world, worldDecl))
-				return worldDecl->IsAbstract;
+				return worldDecl->IsAbstract();
 			return false;
 		}
 
@@ -294,7 +294,7 @@ namespace Spire
 			{
 				if (shaderUsing.Shader->Components.TryGetValue(compName, refComp))
 				{
-					if (refComp->Implementations.First()->SyntaxNode->IsPublic)
+					if (refComp->Implementations.First()->SyntaxNode->IsPublic())
 					{
 						result.Component = refComp.Ptr();
 						result.IsAccessible = true;
@@ -355,7 +355,7 @@ namespace Spire
 			}
 			for (auto & cimpl : comp->Implementations)
 			{
-				if (impl->SyntaxNode->IsOutput != cimpl->SyntaxNode->IsOutput)
+				if (impl->SyntaxNode->IsOutput() != cimpl->SyntaxNode->IsOutput())
 				{
                     err->diagnose(impl->SyntaxNode->Position,
                         Diagnostics::inconsistentSignatureForComponent,
@@ -365,7 +365,7 @@ namespace Spire
 					rs = false;
 					break;
 				}
-				if (impl->SyntaxNode->IsRequire != cimpl->SyntaxNode->IsRequire)
+				if (impl->SyntaxNode->IsRequire() != cimpl->SyntaxNode->IsRequire())
 				{
                     err->diagnose(impl->SyntaxNode->Position,
                         Diagnostics::inconsistentSignatureForComponent,
@@ -375,7 +375,7 @@ namespace Spire
 					rs = false;
 					break;
 				}
-				if (impl->SyntaxNode->IsPublic != cimpl->SyntaxNode->IsPublic)
+				if (impl->SyntaxNode->IsPublic() != cimpl->SyntaxNode->IsPublic())
 				{
                     err->diagnose(impl->SyntaxNode->Position,
                         Diagnostics::inconsistentSignatureForComponent,
@@ -396,7 +396,7 @@ namespace Spire
 					break;
 				}
 			}
-			if (impl->SyntaxNode->IsRequire && comp->Implementations.Count() != 0)
+			if (impl->SyntaxNode->IsRequire() && comp->Implementations.Count() != 0)
 			{
                 err->diagnose(impl->SyntaxNode->Position,
                     Diagnostics::parameterNameConflictsWithExistingDefinition, comp->Name);
@@ -539,7 +539,7 @@ namespace Spire
 				if (subClosure.Value->IsInPlace)
 				{
 					rs = subClosure.Value->FindComponent(name, findInPrivate, includeParams);
-					if (rs && (findInPrivate || rs->Implementations.First()->SyntaxNode->IsPublic))
+					if (rs && (findInPrivate || rs->Implementations.First()->SyntaxNode->IsPublic()))
 						return rs;
 					else
 						rs = nullptr;

--- a/Source/SpireCore/SymbolTable.cpp
+++ b/Source/SpireCore/SymbolTable.cpp
@@ -335,7 +335,7 @@ namespace Spire
 				for (auto & cimpl : comp->Implementations)
 				{
 					for (auto & w : cimpl->Worlds)
-						if (impl->Worlds.Contains(w) && impl->AlternateName == cimpl->AlternateName)
+						if (impl->Worlds.Contains(w))
 						{
                             err->diagnose(impl->SyntaxNode->Position, Diagnostics::componentIsAlreadyDefinedInThatWorld, comp->Name, w);
 							rs = false;
@@ -346,7 +346,7 @@ namespace Spire
 			{
 				for (auto & cimpl : comp->Implementations)
 				{
-					if (cimpl->Worlds.Count() == 0 && impl->Worlds.Count() == 0 && impl->AlternateName == cimpl->AlternateName)
+					if (cimpl->Worlds.Count() == 0 && impl->Worlds.Count() == 0)
 					{
                         err->diagnose(impl->SyntaxNode->Position, Diagnostics::componentIsAlreadyDefined, comp->Name);
 						rs = false;

--- a/Source/SpireCore/SymbolTable.h
+++ b/Source/SpireCore/SymbolTable.h
@@ -52,7 +52,7 @@ namespace Spire
 			bool IsRequire()
 			{
 				for (auto & impl : Implementations)
-					if (impl->SyntaxNode->IsRequire)
+					if (impl->SyntaxNode->IsRequire())
 						return true;
 				return false;
 			}

--- a/Source/SpireCore/SymbolTable.h
+++ b/Source/SpireCore/SymbolTable.h
@@ -23,7 +23,6 @@ namespace Spire
 		class ShaderComponentImplSymbol : public RefObject
 		{
 		public:
-			String AlternateName;
 			EnumerableHashSet<String> Worlds, ExportWorlds, SrcPinnedWorlds;
 			RefPtr<ComponentSyntaxNode> SyntaxNode;
 			EnumerableDictionary<ShaderComponentSymbol *, EnumerableHashSet<RefPtr<ImportExpressionSyntaxNode>>> DependentComponents; // key: dependent components, value: set of import expression nodes (null means implicit reference)
@@ -31,7 +30,6 @@ namespace Spire
 			ShaderComponentImplSymbol() = default;
 			ShaderComponentImplSymbol(const ShaderComponentImplSymbol & other)
 			{
-				AlternateName = other.AlternateName;
 				Worlds = other.Worlds;
 				ExportWorlds = other.ExportWorlds;
 				SrcPinnedWorlds = other.SrcPinnedWorlds;

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -19,20 +19,32 @@ namespace Spire
                 if (scope->decls.TryGetValue(name, decl))
                     return decl;
 
-                scope = scope->Parent;
+                scope = scope->Parent.Ptr();
             }
             return nullptr;
         }
 
         // Decl
 
-        bool Decl::FindSimpleAttribute(String const& key, String& outValue)
+        bool Decl::FindSimpleAttribute(String const& key, Token& outValue)
         {
             for (auto attr : GetLayoutAttributes())
             {
                 if (attr->Key == key)
                 {
                     outValue = attr->Value;
+                    return true;
+                }
+            }
+            return false;
+        }
+        bool Decl::FindSimpleAttribute(String const& key, String& outValue)
+        {
+            for (auto attr : GetLayoutAttributes())
+            {
+                if (attr->Key == key)
+                {
+                    outValue = attr->Value.Content;
                     return true;
                 }
             }
@@ -501,6 +513,21 @@ namespace Spire
 				rs->Members.Add(comp->Clone(ctx));
 			return rs;
 		}
+
+        // UsingFileDecl
+
+        RefPtr<SyntaxNode> UsingFileDecl::Accept(SyntaxVisitor * visitor)
+        {
+            return visitor->VisitUsingFileDecl(this);
+        }
+
+        UsingFileDecl* UsingFileDecl::Clone(CloneContext & ctx)
+        {
+            return CloneSyntaxNodeFields(new UsingFileDecl(*this), ctx);
+        }
+
+        //
+
 		RateSyntaxNode * RateSyntaxNode::Clone(CloneContext & ctx)
 		{
 			return CloneSyntaxNodeFields(new RateSyntaxNode(*this), ctx);

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -8,19 +8,49 @@ namespace Spire
 {
 	namespace Compiler
 	{
-    Decl* Scope::LookUp(String const& name)
-    {
-        Scope* scope = this;
-        while (scope)
-        {
-            Decl* decl = nullptr;
-            if (scope->decls.TryGetValue(name, decl))
-                return decl;
+        // Scope
 
-            scope = scope->Parent;
+        Decl* Scope::LookUp(String const& name)
+        {
+            Scope* scope = this;
+            while (scope)
+            {
+                Decl* decl = nullptr;
+                if (scope->decls.TryGetValue(name, decl))
+                    return decl;
+
+                scope = scope->Parent;
+            }
+            return nullptr;
         }
-        return nullptr;
-    }
+
+        // Decl
+
+        bool Decl::FindSimpleAttribute(String const& key, String& outValue)
+        {
+            for (auto attr : GetLayoutAttributes())
+            {
+                if (attr->Key == key)
+                {
+                    outValue = attr->Value;
+                    return true;
+                }
+            }
+            return false;
+        }
+        bool Decl::HasSimpleAttribute(String const& key)
+        {
+            for (auto attr : GetLayoutAttributes())
+            {
+                if (attr->Key == key)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        //
 
 		bool BasicExpressionType::EqualsImpl(const ExpressionType * type) const
 		{

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -562,19 +562,6 @@ namespace Spire
 			return rs;
 		}
 
-        RefPtr<SyntaxNode> MultiDecl::Accept(SyntaxVisitor * visitor)
-        {
-            return visitor->VisitMultiDecl(this);
-        }
-
-        MultiDecl * MultiDecl::Clone(CloneContext & ctx)
-        {
-            auto rs = CloneSyntaxNodeFields(new MultiDecl(*this), ctx);
-            for (auto& d : rs->decls)
-                d = d->Clone(ctx);
-            return rs;
-        }
-
 		RefPtr<SyntaxNode> StructField::Accept(SyntaxVisitor * visitor)
 		{
 			return visitor->VisitStructField(this);

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -786,7 +786,7 @@ namespace Spire
 		class ChoiceValueSyntaxNode : public ExpressionSyntaxNode
 		{
 		public:
-			String WorldName, AlternateName;
+			String WorldName;
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor *) { return this; }
 			virtual ChoiceValueSyntaxNode * Clone(CloneContext & ctx);
 		};
@@ -979,7 +979,6 @@ namespace Spire
 			RefPtr<TypeSyntaxNode> TypeNode;
 			RefPtr<ExpressionType> Type;
 			RefPtr<RateSyntaxNode> Rate;
-			Token AlternateName;
 			RefPtr<BlockStatementSyntaxNode> BlockStatement;
 			RefPtr<ExpressionSyntaxNode> Expression;
 			List<RefPtr<ParameterSyntaxNode>> Parameters;

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -645,6 +645,9 @@ namespace Spire
         class VarDeclBase : public Decl
         {
         public:
+            // Syntax for type specifier
+			RefPtr<TypeSyntaxNode> TypeNode;
+
             // Resolved type of the variable
 			RefPtr<ExpressionType> Type;
 
@@ -652,32 +655,8 @@ namespace Spire
 			RefPtr<ExpressionSyntaxNode> Expr;
         };
 
-        // A single variable declaration
-        class SingleVarDecl : public VarDeclBase
-        {
-        public:
-			RefPtr<TypeSyntaxNode> TypeNode;
-        };
-
-        // A compound declaration that might declare multiple things,
-        // using C-style declarator syntax
-        class MultiDecl : public Decl
-        {
-        public:
-            // The type specifier that all the declarations share
-			RefPtr<TypeSyntaxNode> TypeNode;
-
-            // The actual decls
-            List<RefPtr<Decl>> decls;
-
-			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
-            virtual MultiDecl * Clone(CloneContext & ctx) override;
-        };
-
-
         // A field of a `struct` type
-		class StructField :
-            public SingleVarDecl // TODO(tfoley): should really allow `MultiDecl` inside a `struct`
+		class StructField : public VarDeclBase
 		{
 		public:
 			StructField()
@@ -762,7 +741,7 @@ namespace Spire
 			In, Out, InOut, Uniform
 		};
 
-		class ParameterSyntaxNode : public SingleVarDecl
+		class ParameterSyntaxNode : public VarDeclBase
 		{
 		public:
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
@@ -1417,16 +1396,6 @@ namespace Spire
 			{
 				return type;
 			}
-
-            virtual RefPtr<MultiDecl> VisitMultiDecl(MultiDecl* decl)
-            {
-                decl->TypeNode = decl->TypeNode->Accept(this).As<TypeSyntaxNode>();
-                for (auto& d : decl->decls)
-                {
-                    d = d->Accept(this).As<Decl>();
-                }
-                return decl;
-            }
 
 			virtual RefPtr<Variable> VisitDeclrVariable(Variable* dclr)
 			{

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -1050,7 +1050,6 @@ namespace Spire
 		{
 		public:
 			bool IsInplace = false;
-			EnumerableDictionary<String, Token> Attributes;
             bool IsPublic() { return HasModifier(ModifierFlag::Public); }
 			Token ShaderName;
 			Token ObjectName;

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -13,18 +13,180 @@ namespace Spire
 		class SyntaxVisitor;
 		class FunctionSyntaxNode;
 
-		enum class VariableModifier
-		{
-			None = 0,
-			Uniform = 1,
-			Out = 2,
-			In = 4,
-			Centroid = 128,
-			Const = 16,
-			Instance = 1024,
-			Builtin = 256,
-			Parameter = 513
-		};
+        // We use a unified representation for modifiers on all declarations.
+        // (Eventually this will also apply to statements that support attributes)
+        //
+        // The parser allows any set of modifiers on any declaration, and we leave
+        // it to later phases of analysis to reject inappropriate uses.
+        // TODO: implement rejection properly.
+        //
+        // Some common modifiers (thos represented by single keywords) are
+        // specified via a simple set of flags.
+        // TODO: consider using a real AST even for these, so we can give good
+        // error messages on confliction modifiers.
+        typedef unsigned int ModifierFlags;
+        enum ModifierFlag : ModifierFlags
+        {
+            None        = 0,
+            Uniform     = 1 << 0,
+            Out         = 1 << 1,
+            In          = 1 << 2,
+            Centroid    = 1 << 3,
+            Const       = 1 << 4,
+            Instance    = 1 << 5,
+            Builtin     = 1 << 6,
+            Parameter   = (1 << 7) | ModifierFlag::Uniform,
+
+            Inline      = 1 << 8,
+            Public      = 1 << 9,
+            Require     = 1 << 10,
+            Param       = (1 << 11) | ModifierFlag::Public,
+            Extern      = 1 << 12,
+            Input       = 1 << 13,
+            Intrinsic   = (1 << 14) | ModifierFlag::Extern,
+
+
+            // TODO(tfoley): This should probably be its own flag
+            InOut       = ModifierFlag::In | ModifierFlag::Out,
+        };
+        //
+        // Other modifiers may have more elaborate data, and so
+        // are represented as heap-allocated objects, in a linked
+        // list.
+        //
+        class Modifier : public RefObject
+        {
+        public:
+            RefPtr<Modifier> next;
+        };
+
+        // A `layout` modifier
+        class LayoutModifier : public Modifier
+        {
+        public:
+            String LayoutString;
+        };
+
+        // An attribute of the form `[Name]` or `[Name: Value]`
+        class SimpleAttribute : public Modifier
+        {
+        public:
+            String Key;
+            String Value;
+        };
+
+        // A set of modifiers attached to a syntax node
+        struct Modifiers
+        {
+            // The first modifier in the linked list of heap-allocated modifiers
+            RefPtr<Modifier> first;
+
+            // The bit-flags for the common modifiers
+            ModifierFlags flags = ModifierFlag::None;
+        };
+
+        // Helper class for iterating over a list of heap-allocated modifiers
+        struct ModifierList
+        {
+            struct Iterator
+            {
+                Modifier* current;
+
+                Modifier* operator*()
+                {
+                    return current;
+                }
+
+                void operator++()
+                {
+                    current = current->next.Ptr();
+                }
+
+                bool operator!=(Iterator other)
+                {
+                    return current != other.current;
+                };
+
+                Iterator()
+                    : current(nullptr)
+                {}
+
+                Iterator(Modifier* modifier)
+                    : current(modifier)
+                {}
+            };
+
+            ModifierList()
+                : modifiers(nullptr)
+            {}
+
+            ModifierList(Modifier* modifiers)
+                : modifiers(modifiers)
+            {}
+
+            Iterator begin() { return Iterator(modifiers); }
+            Iterator end() { return Iterator(nullptr); }
+
+            Modifier* modifiers;
+        };
+
+        // Helper class for iterating over heap-allocated modifiers
+        // of a specific type.
+        template<typename T>
+        struct FilteredModifierList
+        {
+            struct Iterator
+            {
+                Modifier* current;
+
+                T* operator*()
+                {
+                    return (T*) current;
+                }
+
+                void operator++()
+                {
+                    current = Adjust(current->next.Ptr());
+                }
+
+                bool operator!=(Iterator other)
+                {
+                    return current != other.current;
+                };
+
+                Iterator()
+                    : current(nullptr)
+                {}
+
+                Iterator(Modifier* modifier)
+                    : current(modifier)
+                {}
+            };
+
+            FilteredModifierList()
+                : modifiers(nullptr)
+            {}
+
+            FilteredModifierList(Modifier* modifiers)
+                : modifiers(Adjust(modifiers))
+            {}
+
+            Iterator begin() { return Iterator(modifiers); }
+            Iterator end() { return Iterator(nullptr); }
+
+            static Modifier* Adjust(Modifier* modifier)
+            {
+                Modifier* m = modifier;
+                for (;;)
+                {
+                    if (!m) return m;
+                    if (dynamic_cast<T*>(m)) return m;
+                    m = m->next.Ptr();
+                }
+            }
+
+            Modifier* modifiers;
+        };
 
 		enum class BaseType
 		{
@@ -350,7 +512,18 @@ namespace Spire
         public:
             ContainerDecl*  ParentDecl;
 			Token Name;
-			EnumerableDictionary<String, Token> Attributes;
+            Modifiers modifiers;
+
+            bool HasModifier(ModifierFlags flags) { return (modifiers.flags & flags) == flags; }
+
+            template<typename T>
+            FilteredModifierList<T> GetModifiersOfType() { return FilteredModifierList<T>(modifiers.first.Ptr()); }
+
+            FilteredModifierList<SimpleAttribute> GetLayoutAttributes() { return GetModifiersOfType<SimpleAttribute>(); }
+
+            bool FindSimpleAttribute(String const& key, String& outValue);
+            bool HasSimpleAttribute(String const& key);
+
 			virtual Decl * Clone(CloneContext & ctx) = 0;
         };
 
@@ -497,9 +670,6 @@ namespace Spire
             // The actual decls
             List<RefPtr<Decl>> decls;
 
-            // Layout information (shared across the whole decl)
-			String LayoutString;
-
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
             virtual MultiDecl * Clone(CloneContext & ctx) override;
         };
@@ -586,6 +756,7 @@ namespace Spire
 			virtual BlockStatementSyntaxNode * Clone(CloneContext & ctx) override;
 		};
 
+        // TODO(tfoley): Only used by IL at this point
 		enum class ParameterQualifier
 		{
 			In, Out, InOut, Uniform
@@ -594,7 +765,6 @@ namespace Spire
 		class ParameterSyntaxNode : public SingleVarDecl
 		{
 		public:
-			ParameterQualifier Qualifier = ParameterQualifier::In;
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
 			virtual ParameterSyntaxNode * Clone(CloneContext & ctx) override;
 		};
@@ -612,15 +782,12 @@ namespace Spire
 			String InternalName;
 			RefPtr<ExpressionType> ReturnType;
 			RefPtr<TypeSyntaxNode> ReturnTypeNode;
-			bool IsInline;
-			bool IsExtern;
-			bool HasSideEffect;
+            bool IsInline() { return HasModifier(ModifierFlag::Inline); }
+            bool IsExtern() { return HasModifier(ModifierFlag::Extern); }
+            bool HasSideEffect() { return !HasModifier(ModifierFlag::Intrinsic); }
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
 			FunctionSyntaxNode()
 			{
-				IsInline = false;
-				IsExtern = false;
-				HasSideEffect = true;
 			}
 
 			virtual FunctionSyntaxNode * Clone(CloneContext & ctx) override;
@@ -824,7 +991,12 @@ namespace Spire
 		class ComponentSyntaxNode : public Decl
 		{
 		public:
-			bool IsOutput = false, IsPublic = false, IsInline = false, IsRequire = false, IsInput = false, IsParam = false;
+            bool IsOutput()     { return HasModifier(ModifierFlag::Out); }
+            bool IsPublic()     { return HasModifier(ModifierFlag::Public); }
+            bool IsInline()     { return HasModifier(ModifierFlag::Inline) || (Parameters.Count() != 0); }
+            bool IsRequire()    { return HasModifier(ModifierFlag::Require); }
+            bool IsInput()      { return HasModifier(ModifierFlag::Extern); }
+            bool IsParam()      { return HasModifier(ModifierFlag::Param); }
 			RefPtr<TypeSyntaxNode> TypeNode;
 			RefPtr<ExpressionType> Type;
 			RefPtr<RateSyntaxNode> Rate;
@@ -839,7 +1011,7 @@ namespace Spire
 		class WorldSyntaxNode : public Decl
 		{
 		public:
-			bool IsAbstract = false;
+            bool IsAbstract() { return HasModifier(ModifierFlag::Input); }
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor *) override { return this; }
 			virtual WorldSyntaxNode * Clone(CloneContext & ctx) override;
 		};
@@ -848,6 +1020,7 @@ namespace Spire
 		{
 		public:
 			Token StageType;
+			EnumerableDictionary<String, Token> Attributes;
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor *) override { return this; }
 			virtual StageSyntaxNode * Clone(CloneContext & ctx) override;
 		};
@@ -896,7 +1069,8 @@ namespace Spire
 		{
 		public:
 			bool IsInplace = false;
-			bool IsPublic = false;
+			EnumerableDictionary<String, Token> Attributes;
+            bool IsPublic() { return HasModifier(ModifierFlag::Public); }
 			Token ShaderName;
 			Token ObjectName;
 			List<RefPtr<ImportArgumentSyntaxNode>> Arguments;

--- a/Source/SpireLib/SpireLib.cpp
+++ b/Source/SpireLib/SpireLib.cpp
@@ -547,7 +547,7 @@ namespace SpireLib
 						if (comp.Value->Implementations.Count() != 1)
 							continue;
 						auto impl = comp.Value->Implementations.First();
-						if (!impl->SyntaxNode->IsRequire && !impl->SyntaxNode->IsParam)
+						if (!impl->SyntaxNode->IsRequire() && !impl->SyntaxNode->IsParam())
 							continue;
 						ComponentMetaData compMeta;
 						compMeta.Name = comp.Key;
@@ -561,7 +561,7 @@ namespace SpireLib
 							compMeta.Offset = offset;
 							offset += compMeta.Size;
 						}
-						if (impl->SyntaxNode->IsRequire)
+						if (impl->SyntaxNode->IsRequire())
 							meta.Requirements.Add(compMeta);
 						else
 							meta.Parameters.Add(compMeta);

--- a/Source/SpireLib/SpireLib.cpp
+++ b/Source/SpireLib/SpireLib.cpp
@@ -193,12 +193,12 @@ namespace SpireLib
 				units.Add(unit);
 				if (unit.SyntaxNode)
 				{
-					for (auto inc : unit.SyntaxNode->Usings)
+					for (auto inc : unit.SyntaxNode->GetUsings())
 					{
 						bool found = false;
 						for (auto & dir : searchDirs)
 						{
-							String includeFile = Path::Combine(dir, inc.Content);
+							String includeFile = Path::Combine(dir, inc->fileName.Content);
 							if (File::Exists(includeFile))
 							{
 								if (processedUnits.Add(includeFile))
@@ -211,7 +211,7 @@ namespace SpireLib
 						}
 						if (!found)
 						{
-							compileResult.GetErrorWriter()->diagnose(inc.Position, Diagnostics::cannotFindFile, inputFileName);
+							compileResult.GetErrorWriter()->diagnose(inc->fileName.Position, Diagnostics::cannotFindFile, inputFileName);
 						}
 					}
 				}
@@ -605,12 +605,12 @@ namespace SpireLib
 					units.Add(unit);
 					if (unit.SyntaxNode)
 					{
-						for (auto inc : unit.SyntaxNode->Usings)
+						for (auto inc : unit.SyntaxNode->GetUsings())
 						{
 							bool found = false;
 							for (auto & dir : searchDirs)
 							{
-								String includeFile = Path::Combine(dir, inc.Content);
+								String includeFile = Path::Combine(dir, inc->fileName.Content);
 								if (File::Exists(includeFile))
 								{
 									if (processedUnits.Add(includeFile))
@@ -623,7 +623,7 @@ namespace SpireLib
 							}
 							if (!found)
 							{
-								result.GetErrorWriter()->diagnose(inc.Position, Diagnostics::cannotFindFile, inputFileName);
+								result.GetErrorWriter()->diagnose(inc->fileName.Position, Diagnostics::cannotFindFile, inputFileName);
 							}
 						}
 					}


### PR DESCRIPTION
Note: this has been tested against the automated tests (such as they are), but not against the engine example (since it seems to be in a state of flux). Let me know if I should try to test against the engine before checking this in.

The big picture here is that any flavor of declaration is now allowed in any context where declarations are expected (global scope, body of a `struct`, body of a `shader`, etc.), and also any modifier keywords or attributes are allowed on any declaration (you can declare a `public param int foo;` at global scope).

It is (or rather, will be) up to later semantic analysis steps to rule out the cases that shouldn't be allowed, but we know that the parser won't stop us from supporting scenarios like:

- Global variables
- Member functions in `struct` types
- Having component functions just be functions nested inside shader/module declarations
- Struct declarations local to a module/shader
- Typedefs within functions
- Modules within modules

You get the point.