### PR TITLE
Fix up tests for recent syntax changes

### DIFF
--- a/Source/SpireLib/SpireLib.cpp
+++ b/Source/SpireLib/SpireLib.cpp
@@ -637,7 +637,7 @@ namespace SpireLib
 							}
 							if (!found)
 							{
-								result.GetErrorWriter()->diagnose(inc->fileName.Position, Diagnostics::cannotFindFile, inputFileName);
+								result.GetErrorWriter()->diagnose(inc->fileName.Position, Diagnostics::cannotFindFile, inc->fileName);
 							}
 						}
 					}

--- a/Tests/Diagnostics/hull-shader-invalid-domain.spire
+++ b/Tests/Diagnostics/hull-shader-invalid-domain.spire
@@ -43,7 +43,8 @@ pipeline P
     }
 }
 
-shader S : P
+shader S
+    targets P
 {
 	@FineVertex float4 RS_Position = float4(0.0);
 	@ControlPoint float2 tessLevelInner = float2(2.0);

--- a/Tests/Diagnostics/hull-shader-no-domain.spire
+++ b/Tests/Diagnostics/hull-shader-no-domain.spire
@@ -43,7 +43,8 @@ pipeline P
     }
 }
 
-shader S : P
+shader S
+    targets P
 {
 	@FineVertex float4 RS_Position = float4(0.0);
 	@ControlPoint float2 tessLevelInner = float2(2.0);

--- a/Tests/Diagnostics/missing-file.spire.expected
+++ b/Tests/Diagnostics/missing-file.spire.expected
@@ -1,7 +1,7 @@
 result code = -1
 standard error = {
 Tests/Diagnostics/missing-file.spire(0): error 20001: unexpected end of file, expected ';'
-Tests/Diagnostics/missing-file.spire(3): error 2: cannot find file 'Tests/Diagnostics/missing-file.spire'.
+Tests/Diagnostics/missing-file.spire(3): error 2: cannot find file 'does-not-exist.spire'.
 }
 standard output = {
 }

--- a/Tests/FrontEnd/parser-decls.spire
+++ b/Tests/FrontEnd/parser-decls.spire
@@ -31,7 +31,8 @@ module M
 }
 
 // a module can "inherit" from a pipeline
-module M2 : P
+module M2
+	targets P
 {
 }
 

--- a/Tests/FrontEnd/struct.spire
+++ b/Tests/FrontEnd/struct.spire
@@ -19,7 +19,8 @@ Foo makeFoo(float x, float y)
 	return foo;
 }
 
-shader Test : StandardPipeline
+shader Test
+    targets StandardPipeline
 {
 	// Uniform of struct type
 	param Foo foo1;


### PR DESCRIPTION
The main change here was from:

    shader S : PipelineName { ... }

to:

    shader S targets PipelineName { ... }

There is also one small fix related to how we are printing file names when we fail to find a file included with `using`.