### PR TITLE
Lookup rules

### DIFF
--- a/Source/SpireCore/Closure.cpp
+++ b/Source/SpireCore/Closure.cpp
@@ -514,7 +514,7 @@ namespace Spire
                             err->diagnose(existingComp->Implementations.First()->SyntaxNode, Diagnostics::seePreviousDefinition);
 						}
 					}
-					else if (comp.Value->Implementations.First()->SyntaxNode->Parameters.Count() == 0)
+					else if (!comp.Value->Implementations.First()->SyntaxNode->IsComponentFunction())
 					{
 						err->diagnose(comp.Value->Implementations.First()->SyntaxNode, Diagnostics::componentAlreadyDefinedWhenCompiling, comp.Value->UniqueKey, closure->Name);
 						auto currentClosure = subClosure;

--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -466,7 +466,7 @@ namespace Spire
 				for (auto & comp : shader->Definitions)
 				{
 					currentComponent = comp.Ptr();
-					if (comp->SyntaxNode->Parameters.Count())
+					if (comp->SyntaxNode->IsComponentFunction())
 					{
 						auto funcName = GetComponentFunctionName(comp->SyntaxNode.Ptr());
 						if (result.Program->Functions.ContainsKey(funcName))
@@ -479,7 +479,7 @@ namespace Spire
 						result.Program->Functions[funcName] = func;
 						for (auto dep : comp->GetComponentFunctionDependencyClosure())
 						{
-							if (dep->SyntaxNode->Parameters.Count())
+							if (dep->SyntaxNode->IsComponentFunction())
 							{
 								funcSym->ReferencedFunctions.Add(GetComponentFunctionName(dep->SyntaxNode.Ptr()));
 							}
@@ -490,7 +490,7 @@ namespace Spire
 						codeWriter.PushNode();
 						for (auto & dep : comp->GetComponentFunctionDependencyClosure())
 						{
-							if (dep->SyntaxNode->Parameters.Count() == 0)
+							if (!dep->SyntaxNode->IsComponentFunction())
 							{
 								auto paramType = TranslateExpressionType(dep->Type);
 								String paramName = EscapeCodeName("p" + String(id) + "_" + dep->OriginalName);
@@ -501,7 +501,7 @@ namespace Spire
 								id++;
 							}
 						}
-						for (auto & param : comp->SyntaxNode->Parameters)
+						for (auto & param : comp->SyntaxNode->GetParameters())
 						{
 							auto paramType = TranslateExpressionType(param->Type);
 							String paramName = EscapeCodeName("p" + String(id) + "_" + param->Name.Content);
@@ -556,7 +556,7 @@ namespace Spire
 
 					for (auto & comp : components)
 					{
-						if (comp->SyntaxNode->Parameters.Count() == 0)
+						if (!comp->SyntaxNode->IsComponentFunction())
 							VisitComponent(comp);
 					}
 
@@ -769,7 +769,7 @@ namespace Spire
 					{
 						stmt->Expression->Accept(this);
 						returnRegister = PopStack();
-						if (currentComponent->SyntaxNode->Parameters.Count() == 0)
+						if (!currentComponent->SyntaxNode->IsComponentFunction())
 						{
 							if (currentWorld->OutputType->Members.ContainsKey(currentComponent->UniqueName))
 							{
@@ -1185,7 +1185,7 @@ namespace Spire
 						auto funcCompName = expr->FunctionExpr->Tags["ComponentReference"]().As<StringObject>()->Content;
 						auto funcComp = *(currentShader->DefinitionsByComponent[funcCompName]().TryGetValue(currentComponent->World));
 						funcName = GetComponentFunctionName(funcComp->SyntaxNode.Ptr());
-						for (auto & param : funcComp->SyntaxNode->Parameters)
+						for (auto & param : funcComp->SyntaxNode->GetParameters())
 						{
 							if (param->HasModifier(ModifierFlag::Out))
 							{
@@ -1196,7 +1196,7 @@ namespace Spire
 						// push additional arguments
 						for (auto & dep : funcComp->GetComponentFunctionDependencyClosure())
 						{
-							if (dep->SyntaxNode->Parameters.Count() == 0)
+							if (!dep->SyntaxNode->IsComponentFunction())
 							{
 								ILOperand * op = nullptr;
 								if (variables.TryGetValue(dep->UniqueName, op))

--- a/Source/SpireCore/CodeGenerator.cpp
+++ b/Source/SpireCore/CodeGenerator.cpp
@@ -659,7 +659,7 @@ namespace Spire
 				variables.PushScope();
 				codeWriter.PushNode();
 				int id = 0;
-				for (auto &param : function->Parameters)
+				for (auto &param : function->GetParameters())
 				{
 					func->Parameters.Add(param->Name.Content, ILParameter(TranslateExpressionType(param->Type), GetParamQualifier(param.Ptr())));
 					auto op = FetchArg(param->Type.Ptr(), ++id);
@@ -1059,12 +1059,14 @@ namespace Spire
 			{
 				variables.PushScope();
 				List<ILOperand*> arguments;
-				for (int i = 0; i < expr->Arguments.Count(); i++)
+				int argIndex = 0;
+				for (auto param : expr->ImportOperatorDef->GetParameters())
 				{
-					expr->Arguments[i]->Accept(this);
+					expr->Arguments[argIndex]->Accept(this);
 					auto argOp = PopStack();
 					arguments.Add(argOp);
-					variables.Add(expr->ImportOperatorDef->Parameters[i]->Name.Content, argOp);
+					variables.Add(param->Name.Content, argOp);
+					argIndex++;
 				}
 				currentImport = expr;
 				auto oldTypeMapping = genericTypeMappings.TryGetValue(expr->ImportOperatorDef->TypeName.Content);
@@ -1169,7 +1171,7 @@ namespace Spire
 					if (basicType->Func)
 					{
 						funcName = basicType->Func->SyntaxNode->IsExtern() ? basicType->Func->SyntaxNode->Name.Content : basicType->Func->SyntaxNode->InternalName;
-						for (auto & param : basicType->Func->SyntaxNode->Parameters)
+						for (auto & param : basicType->Func->SyntaxNode->GetParameters())
 						{
 							if (param->HasModifier(ModifierFlag::Out))
 							{

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -1,5 +1,7 @@
 #include "Parser.h"
 
+#include <assert.h>
+
 namespace Spire
 {
 	namespace Compiler
@@ -12,7 +14,7 @@ namespace Spire
 		{
         public:
 			int anonymousParamCounter = 0;
-			List<RefPtr<Scope>> scopeStack;
+			RefPtr<Scope> currentScope;
             TokenReader tokenReader;
             DiagnosticSink * sink;
 			String fileName;
@@ -28,18 +30,15 @@ namespace Spire
 			void FillPosition(SyntaxNode * node)
 			{
 				node->Position = tokenReader.PeekLoc();
-				node->Scope = scopeStack.Last();
+				node->Scope = currentScope;
 			}
-			void PushScope()
+			void PushScope(ContainerDecl* containerDecl)
 			{
-				scopeStack.Add(new Scope());
-				if (scopeStack.Count() > 1)
-					scopeStack.Last()->Parent = scopeStack[scopeStack.Count() - 2].Ptr();
+				currentScope = new Scope(currentScope, containerDecl);
 			}
 			void PopScope()
 			{
-				scopeStack.Last() = 0;
-				scopeStack.RemoveAt(scopeStack.Count() - 1);
+				currentScope = currentScope->Parent;
 			}
 			Parser(TokenSpan const& _tokens, DiagnosticSink * sink, String _fileName)
 				: tokenReader(_tokens), sink(sink), fileName(_fileName)
@@ -712,7 +711,7 @@ namespace Spire
             DeclaratorInfo const&       declaratorInfo,
             RefPtr<FunctionSyntaxNode>  decl)
         {
-            parser->PushScope();
+            parser->PushScope(decl.Ptr());
 
             parser->anonymousParamCounter = 0;
             parser->FillPosition(decl.Ptr());
@@ -735,7 +734,7 @@ namespace Spire
             DeclaratorInfo const&       declaratorInfo,
             RefPtr<ComponentSyntaxNode> decl)
         {
-            parser->PushScope();
+            parser->PushScope(decl.Ptr());
 
             parser->anonymousParamCounter = 0;
             parser->FillPosition(decl.Ptr());
@@ -946,6 +945,10 @@ namespace Spire
             if (decl)
             {
                 decl->modifiers = modifiers;
+                if (containerDecl)
+                {
+                    containerDecl->Members.Add(decl);
+                }
             }
             return decl;
         }
@@ -970,7 +973,7 @@ namespace Spire
                 if (decl)
                 {
                     decl->ParentDecl = containerDecl;
-                    containerDecl->Members.Add(decl);
+                    //containerDecl->Members.Add(decl);
                 }
                 TryRecover(parser);
             }
@@ -978,12 +981,14 @@ namespace Spire
 
 		RefPtr<ProgramSyntaxNode> Parser::ParseProgram()
 		{
-			scopeStack.Add(new Scope());
 			RefPtr<ProgramSyntaxNode> program = new ProgramSyntaxNode();
+			PushScope(program.Ptr());
 			program->Position = CodePosition(0, 0, 0, fileName);
-			program->Scope = scopeStack.Last();
+			program->Scope = currentScope;
             ParseDeclBody(this, program.Ptr(), TokenType::EndOfFile);
-			scopeStack.Clear();
+			PopScope();
+			assert(!currentScope.Ptr());
+			currentScope = nullptr;
 			return program;
 		}
 
@@ -991,7 +996,7 @@ namespace Spire
 		{
 			RefPtr<InterfaceSyntaxNode> node = new InterfaceSyntaxNode();
 			ReadToken("interface");
-			PushScope();
+			PushScope(node.Ptr());
 			FillPosition(node.Ptr());
 			node->Name = ReadToken(TokenType::Identifier);
 			ReadToken(TokenType::LBrace);
@@ -1009,7 +1014,7 @@ namespace Spire
 			}
 			else
 				ReadToken("shader");
-			PushScope();
+			PushScope(shader.Ptr());
 			FillPosition(shader.Ptr());
 			shader->Name = ReadToken(TokenType::Identifier);
 			while (LookAheadToken("targets") || LookAheadToken("implements"))
@@ -1040,7 +1045,7 @@ namespace Spire
 			RefPtr<TemplateShaderSyntaxNode> shader = new TemplateShaderSyntaxNode();
 			ReadToken("template");
 			ReadToken("shader");
-			PushScope();
+			PushScope(shader.Ptr());
 			FillPosition(shader.Ptr());
 			shader->Name = ReadToken(TokenType::Identifier);
 			ReadToken(TokenType::LParent);
@@ -1074,7 +1079,7 @@ namespace Spire
 		{
 			RefPtr<PipelineSyntaxNode> pipeline = new PipelineSyntaxNode();
 			ReadToken("pipeline");
-			PushScope();
+			PushScope(pipeline.Ptr());
 			FillPosition(pipeline.Ptr());
 			pipeline->Name = ReadToken(TokenType::Identifier);
 			if (AdvanceIf(this, TokenType::Colon))
@@ -1210,7 +1215,7 @@ namespace Spire
 		RefPtr<ImportOperatorDefSyntaxNode> Parser::ParseImportOperator()
 		{
 			RefPtr<ImportOperatorDefSyntaxNode> op = new ImportOperatorDefSyntaxNode();
-			PushScope();
+			PushScope(op.Ptr());
 			FillPosition(op.Ptr());
 			ReadToken("import");
 			ReadToken(TokenType::LParent);
@@ -1251,13 +1256,15 @@ namespace Spire
 			return op;
 		}
 
+        // TODO(tfoley): this definition is now largely redundant (only
+        // used to parse requirements for import operators)
 		RefPtr<FunctionSyntaxNode> Parser::ParseFunction(bool parseBody)
 		{
 			anonymousParamCounter = 0;
 			RefPtr<FunctionSyntaxNode> function = new FunctionSyntaxNode();
             function->modifiers = ParseModifiers(this);
 			
-			PushScope();
+			PushScope(function.Ptr());
 			function->ReturnTypeNode = ParseType();
 			FillPosition(function.Ptr());
 			Token name;
@@ -1382,8 +1389,10 @@ namespace Spire
 
 		RefPtr<BlockStatementSyntaxNode> Parser::ParseBlockStatement()
 		{
+			RefPtr<ScopeDecl> scopeDecl = new ScopeDecl();
 			RefPtr<BlockStatementSyntaxNode> blockStatement = new BlockStatementSyntaxNode();
-			PushScope();
+            blockStatement->scopeDecl = scopeDecl;
+			PushScope(scopeDecl.Ptr());
 			ReadToken(TokenType::LBrace);
 			if(!tokenReader.IsAtEnd())
 			{
@@ -1407,7 +1416,8 @@ namespace Spire
 			RefPtr<VarDeclrStatementSyntaxNode>varDeclrStatement = new VarDeclrStatementSyntaxNode();
 		
 			FillPosition(varDeclrStatement.Ptr());
-            varDeclrStatement->decl = ParseDecl(this, nullptr);
+            auto decl = ParseDecl(this, currentScope->containerDecl);
+            varDeclrStatement->decl = decl;
 			return varDeclrStatement;
 		}
 
@@ -1430,8 +1440,10 @@ namespace Spire
 
 		RefPtr<ForStatementSyntaxNode> Parser::ParseForStatement()
 		{
+			RefPtr<ScopeDecl> scopeDecl = new ScopeDecl();
 			RefPtr<ForStatementSyntaxNode> stmt = new ForStatementSyntaxNode();
-			PushScope();
+            stmt->scopeDecl = scopeDecl;
+			PushScope(scopeDecl.Ptr());
 			FillPosition(stmt.Ptr());
 			ReadToken("for");
 			ReadToken(TokenType::LParent);
@@ -1464,21 +1476,18 @@ namespace Spire
 		RefPtr<WhileStatementSyntaxNode> Parser::ParseWhileStatement()
 		{
 			RefPtr<WhileStatementSyntaxNode> whileStatement = new WhileStatementSyntaxNode();
-			PushScope();
 			FillPosition(whileStatement.Ptr());
 			ReadToken("while");
 			ReadToken(TokenType::LParent);
 			whileStatement->Predicate = ParseExpression();
 			ReadToken(TokenType::RParent);
 			whileStatement->Statement = ParseStatement();
-			PopScope();
 			return whileStatement;
 		}
 
 		RefPtr<DoWhileStatementSyntaxNode> Parser::ParseDoWhileStatement()
 		{
 			RefPtr<DoWhileStatementSyntaxNode> doWhileStatement = new DoWhileStatementSyntaxNode();
-			PushScope();
 			FillPosition(doWhileStatement.Ptr());
 			ReadToken("do");
 			doWhileStatement->Statement = ParseStatement();
@@ -1487,7 +1496,6 @@ namespace Spire
 			doWhileStatement->Predicate = ParseExpression();
 			ReadToken(TokenType::RParent);
 			ReadToken(TokenType::Semicolon);
-			PopScope();
 			return doWhileStatement;
 		}
 

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -746,7 +746,7 @@ namespace Spire
             parser->ReadToken(TokenType::LParent);
             while (!AdvanceIfMatch(parser, TokenType::RParent))
             {
-                decl->Parameters.Add(parser->ParseParameter());
+                decl->Members.Add(parser->ParseParameter());
                 if (AdvanceIf(parser, TokenType::RParent))
                     break;
                 parser->ReadToken(TokenType::Comma);

--- a/Source/SpireCore/Parser.cpp
+++ b/Source/SpireCore/Parser.cpp
@@ -723,7 +723,7 @@ namespace Spire
             parser->ReadToken(TokenType::LParent);
             while (!AdvanceIfMatch(parser, TokenType::RParent))
             {
-                decl->Parameters.Add(parser->ParseParameter());
+                decl->Members.Add(parser->ParseParameter());
                 if (AdvanceIf(parser, TokenType::RParent))
                     break;
                 parser->ReadToken(TokenType::Comma);
@@ -1234,7 +1234,7 @@ namespace Spire
 			ReadToken(TokenType::LParent);
 			while (!AdvanceIf(this, TokenType::RParent))
 			{
-				op->Parameters.Add(ParseParameter());
+				op->Members.Add(ParseParameter());
 				if (AdvanceIf(this, TokenType::RParent))
 					break;
                 ReadToken(TokenType::Comma);
@@ -1286,7 +1286,7 @@ namespace Spire
 			ReadToken(TokenType::LParent);
 			while(!AdvanceIfMatch(this, TokenType::RParent))
 			{
-				function->Parameters.Add(ParseParameter());
+				function->Members.Add(ParseParameter());
 				if (AdvanceIf(this, TokenType::RParent))
 					break;
 				ReadToken(TokenType::Comma);

--- a/Source/SpireCore/SemanticsVisitor.cpp
+++ b/Source/SpireCore/SemanticsVisitor.cpp
@@ -342,7 +342,6 @@ namespace Spire
 						else
 							paraNames.Add(para->Name.Content);
 						para->Type = TranslateTypeNode(para->TypeNode);
-						op->Scope->decls.AddIfNotExists(para->Name.Content, para.Ptr());
 						if (para->Type->Equals(ExpressionType::Void.Ptr()))
 						{
 							getSink()->diagnose(para.Ptr(), Diagnostics::parameterCannotBeVoid);
@@ -721,7 +720,6 @@ namespace Spire
 				for (auto & param : comp->GetParameters())
 				{
 					param->Accept(this);
-					comp->Scope->decls.Add(param->Name.Content, param.Ptr());
 				}
 				if (comp->Expression)
 				{
@@ -943,7 +941,6 @@ namespace Spire
 					else
 						paraNames.Add(para->Name.Content);
 					para->Type = TranslateTypeNode(para->TypeNode);
-					functionNode->Scope->decls.AddIfNotExists(para->Name.Content, para.Ptr());
 					if (para->Type->Equals(ExpressionType::Void.Ptr()))
 						getSink()->diagnose(para, Diagnostics::parameterCannotBeVoid);
 					internalName << "@" << para->Type->ToString();
@@ -1072,9 +1069,6 @@ namespace Spire
 
 			virtual RefPtr<Variable> VisitDeclrVariable(Variable* varDecl)
 			{
-				if (varDecl->Scope->decls.ContainsKey(varDecl->Name.Content))
-					getSink()->diagnose(varDecl, Diagnostics::variableNameAlreadyDefined, varDecl->Name);
-
 				RefPtr<ExpressionType> type = TranslateTypeNode(varDecl->TypeNode);
 				if (type->IsTextureOrSampler() || type->AsGenericType())
 				{
@@ -1089,8 +1083,6 @@ namespace Spire
 					getSink()->diagnose(varDecl, Diagnostics::invalidTypeVoid);
 				if (varDecl->Type->IsArray() && varDecl->Type->AsArrayType()->ArrayLength <= 0)
 					getSink()->diagnose(varDecl, Diagnostics::invalidArraySize);
-
-				varDecl->Scope->decls.AddIfNotExists(varDecl->Name.Content, varDecl);
 				if (varDecl->Expr != NULL)
 				{
 					varDecl->Expr = varDecl->Expr->Accept(this).As<ExpressionSyntaxNode>();

--- a/Source/SpireCore/SymbolTable.cpp
+++ b/Source/SpireCore/SymbolTable.cpp
@@ -121,7 +121,7 @@ namespace Spire
 						if (op->SourceWorld.Content == world0)
 						{
 							ImportPath np = p;
-							if (op->Parameters.Count() != 0)
+							if (op->GetParameters().Count() != 0)
 								np.IsImplicitPath = false;
 							for (auto &req : op->Requirements)
 								np.TypeRequirements.Add(req.Ptr());
@@ -436,7 +436,7 @@ namespace Spire
 				auto retType = PrintType(req->ReturnType, typeStr);
 				StringBuilder sbInternalName;
 				sbInternalName << req->Name.Content;
-				for (auto & op : req->Parameters)
+				for (auto & op : req->GetParameters())
 				{
 					sbInternalName << "@" << PrintType(op->Type, typeStr);
 				}

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -15,9 +15,11 @@ namespace Spire
             Scope* scope = this;
             while (scope)
             {
-                Decl* decl = nullptr;
-                if (scope->decls.TryGetValue(name, decl))
-                    return decl;
+                for (auto m : scope->containerDecl->Members)
+                {
+                    if (m->Name.Content == name)
+                        return m.Ptr();
+                }
 
                 scope = scope->Parent.Ptr();
             }
@@ -241,6 +243,27 @@ namespace Spire
 			rs->Body = Body->Clone(ctx);
 			return rs;
 		}
+
+        //
+
+        RefPtr<SyntaxNode> ScopeDecl::Accept(SyntaxVisitor * visitor)
+        {
+            return visitor->VisitScopeDecl(this);
+        }
+
+        ScopeDecl* ScopeDecl::Clone(CloneContext & ctx)
+        {
+            auto rs = CloneSyntaxNodeFields(new ScopeDecl(*this), ctx);
+            for (auto & member : rs->Members)
+            {
+                member = member->Clone(ctx);
+            }
+            return rs;
+        }
+
+
+        //
+
 		RefPtr<SyntaxNode> BlockStatementSyntaxNode::Accept(SyntaxVisitor * visitor)
 		{
 			return visitor->VisitBlockStatement(this);

--- a/Source/SpireCore/Syntax.cpp
+++ b/Source/SpireCore/Syntax.cpp
@@ -233,10 +233,9 @@ namespace Spire
 		FunctionSyntaxNode * FunctionSyntaxNode::Clone(CloneContext & ctx)
 		{
 			auto rs = CloneSyntaxNodeFields(new FunctionSyntaxNode(*this), ctx);
-			rs->Parameters.Clear();
-			for (auto & param : Parameters)
+			for (auto & member : rs->Members)
 			{
-				rs->Parameters.Add(param->Clone(ctx));
+				member = member->Clone(ctx);
 			}
 			rs->ReturnTypeNode = ReturnTypeNode->Clone(ctx);
 			rs->Body = Body->Clone(ctx);

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -606,22 +606,32 @@ namespace Spire
 				return count;
 			}
 
+            List<RefPtr<T>> ToArray()
+            {
+                List<RefPtr<T>> result;
+                for (auto element : (*this))
+                {
+                    result.Add(element);
+                }
+                return result;
+            }
+
 			Element* mBegin;
 			Element* mEnd;
 		};
 
-		// A "container" decl is a parent to other declarations
-		class ContainerDecl : public Decl
-		{
-		public:
-			List<RefPtr<Decl>> Members;
+        // A "container" decl is a parent to other declarations
+        class ContainerDecl : public Decl
+        {
+        public:
+            List<RefPtr<Decl>> Members;
 
-			template<typename T>
-			FilteredMemberList<T> GetMembersOfType()
-			{
-				return FilteredMemberList<T>(Members);
-			}
-		};
+            template<typename T>
+            FilteredMemberList<T> GetMembersOfType()
+            {
+                return FilteredMemberList<T>(Members);
+            }
+        };
 
 		enum class ExpressionAccess
 		{
@@ -761,10 +771,13 @@ namespace Spire
 			virtual ParameterSyntaxNode * Clone(CloneContext & ctx) override;
 		};
 
-		class FunctionDeclBase : public Decl
+		class FunctionDeclBase : public ContainerDecl
 		{
 		public:
-			List<RefPtr<ParameterSyntaxNode>> Parameters;
+			FilteredMemberList<ParameterSyntaxNode> GetParameters()
+			{
+				return GetMembersOfType<ParameterSyntaxNode>();
+			}
 			RefPtr<BlockStatementSyntaxNode> Body;
 		};
 
@@ -1261,8 +1274,8 @@ namespace Spire
 			virtual RefPtr<FunctionSyntaxNode> VisitFunction(FunctionSyntaxNode* func)
 			{
 				func->ReturnTypeNode = func->ReturnTypeNode->Accept(this).As<TypeSyntaxNode>();
-				for (auto & param : func->Parameters)
-					param = param->Accept(this).As<ParameterSyntaxNode>();
+				for (auto & member : func->Members)
+					member = member->Accept(this).As<Decl>();
 				if (func->Body)
 					func->Body = func->Body->Accept(this).As<BlockStatementSyntaxNode>();
 				return func;

--- a/Source/SpireCore/Syntax.h
+++ b/Source/SpireCore/Syntax.h
@@ -993,12 +993,12 @@ namespace Spire
 			virtual RateSyntaxNode * Clone(CloneContext & ctx) override;
 		};
 
-		class ComponentSyntaxNode : public Decl
+		class ComponentSyntaxNode : public ContainerDecl
 		{
 		public:
 			bool IsOutput() { return HasModifier(ModifierFlag::Out); }
 			bool IsPublic() { return HasModifier(ModifierFlag::Public); }
-			bool IsInline() { return HasModifier(ModifierFlag::Inline) || (Parameters.Count() != 0); }
+			bool IsInline() { return HasModifier(ModifierFlag::Inline) || IsComponentFunction(); }
 			bool IsRequire() { return HasModifier(ModifierFlag::Require); }
 			bool IsInput() { return HasModifier(ModifierFlag::Extern); }
 			bool IsParam() { return HasModifier(ModifierFlag::Param); }
@@ -1007,7 +1007,11 @@ namespace Spire
 			RefPtr<RateSyntaxNode> Rate;
 			RefPtr<BlockStatementSyntaxNode> BlockStatement;
 			RefPtr<ExpressionSyntaxNode> Expression;
-			List<RefPtr<ParameterSyntaxNode>> Parameters;
+			FilteredMemberList<ParameterSyntaxNode> GetParameters()
+			{
+				return GetMembersOfType<ParameterSyntaxNode>();
+			}
+			bool IsComponentFunction() { return GetParameters().Count() != 0; }
 			virtual RefPtr<SyntaxNode> Accept(SyntaxVisitor * visitor) override;
 			virtual ComponentSyntaxNode * Clone(CloneContext & ctx) override;
 		};

--- a/Source/SpireCore/VariantIR.cpp
+++ b/Source/SpireCore/VariantIR.cpp
@@ -251,7 +251,7 @@ namespace Spire
 			for (auto & dep : Dependency)
 			{
 				dependencyClosure.Add(dep);
-				if (dep->SyntaxNode->Parameters.Count())
+				if (dep->SyntaxNode->IsComponentFunction())
 				{
 					for (auto & x : dep->GetComponentFunctionDependencyClosure())
 						dependencyClosure.Add(x);


### PR DESCRIPTION
The basic idea here is to start to unify how name lookup is performed, so that:

- Names are always looked up using `Scope`s
- All `Scope`s are based on the named declarations within some `ContainerDecl`

This PR thus includes a few changes to make things be `ContainerDecl`s that weren't before, and then a change to make the `Scope` type use the `ContainerDecl` to enumerate members, rather than maintaining its own `Dictionary`.

Nothing really interesting happens in this change (it shouldn't alter functionality at all), but it should make it possible for subsequent changes to remove the various special-case lookup rules being employed.