### PR TITLE
LibString.cpp

### DIFF
--- a/Source/CoreLib/LibString.cpp
+++ b/Source/CoreLib/LibString.cpp
@@ -17,8 +17,11 @@ namespace CoreLib
 		}
 		String operator+(const char * op1, const String & op2)
 		{
-			if(!op2.buffer)
+			if(!op2.buffer)		// no string 2 - return first
 				return String(op1);
+
+            if (!op1)			// no base string?!  return the second string
+                return op2;
 
 			return StringConcat(op1, (int)strlen(op1), op2.buffer.Ptr(), op2.length);
 		}


### PR DESCRIPTION
Without this line a crash on edge case can happen.  
In the case of running the base hello world on my PC this is what I see and the change resolved the issue.